### PR TITLE
[codex] Redesign Fate tracker as rulebook page

### DIFF
--- a/layouts/fate-of-the-fellowship/list.html
+++ b/layouts/fate-of-the-fellowship/list.html
@@ -27,51 +27,40 @@
 
 <section class="section fate-page">
   <div class="container">
-    <div class="fate-ledger">
-      <header class="fate-ledger-header fate-kenney-hero">
+    <div class="fate-ledger fate-rulebook-spread">
+      <header class="fate-ledger-header fate-rulebook-hero">
         <a href="/" class="fate-return-link">Exit to site</a>
-        <div class="fate-hero-panel">
-          <img
-            class="fate-kenney-divider"
-            src="/images/fate-of-the-fellowship/kenney/divider-gold.png"
-            alt=""
-            aria-hidden="true"
-          />
-          <p class="fate-hero-pretitle">The innkeeper's record of</p>
+        <div class="fate-hero-plate">
+          <p class="fate-hero-pretitle">A field record for</p>
           <h1>Fate of the Fellowship</h1>
+          <p class="fate-script-band" aria-hidden="true">ᚠ ᚢ ᚦ ᚨ ᚱ ᚲ ᚷ ᚹ ᚺ ᚾ ᛁ ᛃ ᛇ ᛈ ᛉ ᛋ ᛏ ᛒ ᛖ ᛗ ᛚ ᛜ ᛞ ᛟ</p>
           <p class="fate-hero-tagline">
             Heroes called <span aria-hidden="true">&bull;</span> Quests assigned <span aria-hidden="true">&bull;</span> Tales worth keeping
           </p>
           {{ with .Content }}
           <div class="fate-intro">{{ . }}</div>
           {{ end }}
-          <a class="fate-enter-link" href="#fate-overview-heading">Enter the ledger</a>
-          <img
-            class="fate-kenney-divider is-lower"
-            src="/images/fate-of-the-fellowship/kenney/divider-green.png"
-            alt=""
-            aria-hidden="true"
-          />
+          <a class="fate-enter-link" href="#fate-overview-heading">Read the record</a>
         </div>
       </header>
 
-      <section class="fate-section fate-briefing-grid" aria-label="Innkeeper notes">
-        <article class="fate-briefing-card">
-          <span class="fate-briefing-label">House rule</span>
-          <p>Only companions and quests that have actually reached the table earn ink in the ledger. Empty boasts can wait outside with the ponies.</p>
+      <section class="fate-section fate-briefing-grid fate-rulebook-callouts" aria-label="Table notes">
+        <article class="fate-briefing-card fate-callout-box">
+          <span class="fate-briefing-label">Table rule</span>
+          <p>Only companions and quests that have actually reached the table earn ink in the record. Empty boasts can wait outside with the ponies.</p>
         </article>
-        <article class="fate-briefing-card">
-          <span class="fate-briefing-label">Inn gossip</span>
+        <article class="fate-briefing-card fate-callout-box">
+          <span class="fate-briefing-label">Margin note</span>
           <p>Victories are toasted. Defeats are also toasted, but with a sterner look toward Mordor and fewer second breakfasts.</p>
         </article>
       </section>
 
       <section class="fate-section fate-overview-section" aria-labelledby="fate-overview-heading">
         <div class="fate-section-heading">
-          <h2 id="fate-overview-heading">Overview</h2>
-          <p>The road so far, as remembered by witnesses with mugs in hand.</p>
+          <h2 id="fate-overview-heading">The road so far</h2>
+          <p>The record as it stands before the next company sets out.</p>
         </div>
-        <div class="fate-overview-grid">
+        <div class="fate-overview-grid fate-stat-strip">
           <article class="fate-overview-card">
             <span class="fate-overview-label">Journeys logged</span>
             <strong>{{ $totalSessions }}</strong>
@@ -163,7 +152,7 @@
         </div>
         <div class="fate-log-list">
           {{ if gt (len $sessions) 0 }}
-          {{ range $session := $sessions }}
+          {{ range $sessionIndex, $session := $sessions }}
           <article class="fate-log-card">
             <div class="fate-log-topline">
               <span class="fate-result-seal is-{{ $session.result }}">{{ title $session.result }}</span>
@@ -201,6 +190,9 @@
               </figure>
             {{ end }}
           </article>
+          {{ if lt (add $sessionIndex 1) (len $sessions) }}
+          <div class="fate-session-separator" aria-hidden="true">ᚠ ᚢ ᚦ ᚨ ᚱ ᚲ ᚷ ᚹ ᚺ</div>
+          {{ end }}
           {{ end }}
           {{ else }}
           <article class="fate-log-card fate-empty-log">
@@ -213,7 +205,7 @@
 
       <section class="fate-section fate-actions-section" aria-labelledby="fate-actions-heading">
         <div class="fate-section-heading">
-          <h2 id="fate-actions-heading">Add a tale to the ledger</h2>
+          <h2 id="fate-actions-heading">Add a tale to the record</h2>
           <p>New sessions live as YAML entries in Git.</p>
         </div>
         <div class="fate-actions">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -81,7 +81,7 @@
 />
 {{ if eq .RelPermalink "/fate-of-the-fellowship/" }}
 <link
-  href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700;900&family=IM+Fell+English:ital@0;1&family=IM+Fell+English+SC&family=Uncial+Antiqua&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Cinzel+Decorative:wght@700;900&family=IM+Fell+English:ital@0;1&family=IM+Fell+English+SC&family=Noto+Sans+Runic&display=swap"
   rel="stylesheet"
 />
 {{ end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -2579,236 +2579,326 @@ body.page-nemesis .social-link:focus-visible {
   }
 }
 
+/* Fate of the Fellowship rulebook redesign: pale parchment, dark ink, and sparse runes. */
+html:has(body.page-fate-of-the-fellowship),
 body.page-fate-of-the-fellowship {
-  --fate-ink: #23180f;
-  --fate-ink-soft: #4b3524;
-  --fate-parchment: #e4d3aa;
-  --fate-parchment-deep: #c8a96f;
-  --fate-brass: #c9973d;
-  --fate-forest: #263c26;
-  --fate-forest-dark: #122316;
-  --fate-oxblood: #7c2725;
-  --fate-wax: #a7352d;
-  --fate-charcoal: #15100b;
-  --fate-shadow: rgba(10, 6, 3, 0.58);
+  --fate-ink: #25190f;
+  --fate-ink-soft: #4a321f;
+  --fate-green: #26351f;
+  --fate-green-soft: #51643c;
+  --fate-paper: #efe0b7;
+  --fate-paper-light: #f8efd8;
+  --fate-paper-deep: #d4b56f;
+  --fate-rule: #5f4124;
+  --fate-gold: #c79a45;
+  --fate-rust: #8e2f24;
+  --fate-shadow: rgba(21, 12, 6, 0.58);
   background:
-    radial-gradient(circle at 14% 12%, rgba(201, 151, 61, 0.22), transparent 23rem),
-    radial-gradient(circle at 86% 8%, rgba(38, 60, 38, 0.36), transparent 26rem),
-    linear-gradient(90deg, rgba(0, 0, 0, 0.36) 0 2px, transparent 2px 8px),
-    linear-gradient(180deg, #21140c 0%, #160f0a 45%, #0f0b08 100%);
+    radial-gradient(circle at 12% 18%, rgba(199, 154, 69, 0.18), transparent 20rem),
+    radial-gradient(circle at 88% 10%, rgba(38, 53, 31, 0.24), transparent 24rem),
+    linear-gradient(180deg, #140d08 0%, #080604 100%);
+  color: var(--fate-ink);
 }
 
+body.page-fate-of-the-fellowship .site-header,
 body.page-fate-of-the-fellowship .site-footer {
-  background: #0f0b08;
-}
-
-body.page-fate-of-the-fellowship .site-header {
-  background:
-    linear-gradient(180deg, rgba(18, 11, 6, 0.98), rgba(10, 7, 4, 0.96)),
-    repeating-linear-gradient(90deg, rgba(210, 174, 101, 0.08) 0 1px, transparent 1px 14px);
-  border-bottom-color: rgba(185, 144, 70, 0.45);
-  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.46);
-}
-
-body.page-fate-of-the-fellowship .site-header::after,
-body.page-fate-of-the-fellowship .site-footer::before {
-  background: linear-gradient(90deg, transparent, rgba(197, 151, 73, 0.72), transparent);
-  opacity: 0.62;
-  animation: none;
-}
-
-body.page-fate-of-the-fellowship .site-logo {
-  background: none;
-  background-clip: border-box;
-  -webkit-background-clip: border-box;
-  -webkit-text-fill-color: #d6bd75;
-  color: #d6bd75;
-  filter: none;
-  animation: none;
-}
-
-body.page-fate-of-the-fellowship .main-nav a,
-body.page-fate-of-the-fellowship .nav-link {
-  color: #eadbb1;
-}
-
-body.page-fate-of-the-fellowship .main-nav a:hover,
-body.page-fate-of-the-fellowship .nav-link:hover,
-body.page-fate-of-the-fellowship .nav-dropdown details[open] > summary.nav-link {
-  color: #f5edcf;
-}
-
-body.page-fate-of-the-fellowship .social-link svg,
-body.page-fate-of-the-fellowship .footer-social-link svg {
-  fill: #d6bd75;
-}
-
-body.page-fate-of-the-fellowship .site-footer {
-  background:
-    linear-gradient(180deg, rgba(15, 10, 6, 0.96), rgba(7, 5, 3, 0.98)),
-    radial-gradient(circle at 50% 0%, rgba(106, 73, 35, 0.2), transparent 30rem);
-  border-top-color: rgba(185, 144, 70, 0.4);
+  display: none;
 }
 
 body.page-fate-of-the-fellowship .fate-page {
   position: relative;
   isolation: isolate;
   min-height: 100vh;
-  padding: clamp(2rem, 5vw, 4.5rem) 0;
-  color: var(--fate-ink);
+  padding: clamp(1rem, 3vw, 2.5rem) 0;
   background:
-    radial-gradient(circle at 50% 0%, rgba(201, 151, 61, 0.12), transparent 28rem),
-    linear-gradient(180deg, rgba(18, 35, 22, 0.28), transparent 26rem);
-}
-
-body.page-fate-of-the-fellowship .fate-page::before {
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  content: "";
-  background:
-    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
-    linear-gradient(180deg, rgba(0, 0, 0, 0.18) 1px, transparent 1px);
-  background-size: 72px 100%, 100% 46px;
-  mix-blend-mode: soft-light;
-  opacity: 0.55;
+    radial-gradient(circle at 50% 0%, rgba(248, 239, 216, 0.08), transparent 42rem),
+    linear-gradient(180deg, rgba(38, 53, 31, 0.18), transparent 24rem);
 }
 
 body.page-fate-of-the-fellowship .fate-page .container {
-  width: min(1180px, calc(100vw - 2rem));
+  width: min(1280px, calc(100vw - 1.5rem));
+  max-width: none;
 }
 
 body.page-fate-of-the-fellowship .fate-ledger {
   position: relative;
   display: grid;
-  gap: clamp(1.1rem, 2vw, 1.75rem);
-  padding: clamp(1rem, 3vw, 2rem);
-  border: 1px solid rgba(201, 151, 61, 0.38);
-  border-radius: 8px;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  padding: clamp(1rem, 2vw, 1.75rem) clamp(0.8rem, 2vw, 1.5rem);
+  overflow: hidden;
+  border: 2px solid #2f2114;
+  border-radius: 3px;
   background:
-    linear-gradient(135deg, rgba(228, 211, 170, 0.95), rgba(200, 169, 111, 0.9)),
-    repeating-linear-gradient(0deg, rgba(35, 24, 15, 0.035) 0 1px, transparent 1px 7px);
+    radial-gradient(circle at 16% 24%, rgba(255, 248, 224, 0.78), transparent 16rem),
+    radial-gradient(circle at 85% 12%, rgba(212, 181, 111, 0.28), transparent 18rem),
+    linear-gradient(180deg, rgba(248, 239, 216, 0.98), rgba(226, 204, 151, 0.94)),
+    repeating-linear-gradient(90deg, rgba(37, 25, 15, 0.028) 0 1px, transparent 1px 17px),
+    repeating-linear-gradient(0deg, rgba(37, 25, 15, 0.025) 0 1px, transparent 1px 11px);
   box-shadow:
-    0 30px 80px var(--fate-shadow),
-    inset 0 0 0 1px rgba(255, 252, 228, 0.46);
+    0 34px 90px var(--fate-shadow),
+    inset 0 0 0 8px rgba(95, 65, 36, 0.18),
+    inset 0 0 0 10px rgba(255, 248, 224, 0.36);
 }
 
 body.page-fate-of-the-fellowship .fate-ledger::before,
 body.page-fate-of-the-fellowship .fate-ledger::after {
-  position: absolute;
-  width: 5.5rem;
-  height: 5.5rem;
-  border-radius: 50%;
-  content: "";
-  background:
-    radial-gradient(circle, rgba(167, 53, 45, 0.86) 0 32%, rgba(124, 39, 37, 0.94) 33% 56%, rgba(68, 21, 18, 0.12) 57% 100%);
-  opacity: 0.18;
+  display: none;
 }
 
-body.page-fate-of-the-fellowship .fate-ledger::before {
-  top: 1rem;
-  right: 1rem;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger::after {
-  bottom: 1rem;
-  left: 1rem;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header {
+body.page-fate-of-the-fellowship .fate-rulebook-hero,
+body.page-fate-of-the-fellowship .fate-section {
   position: relative;
   z-index: 1;
+}
+
+body.page-fate-of-the-fellowship .fate-rulebook-hero {
   display: grid;
-  gap: 0.75rem;
-  padding: clamp(1.25rem, 3vw, 2rem);
-  border: 1px solid rgba(75, 53, 36, 0.24);
-  border-radius: 8px;
+  justify-items: center;
+  min-height: clamp(22rem, 34vw, 29rem);
+  padding: clamp(2.2rem, 4vw, 3.6rem) clamp(1rem, 5vw, 4.2rem);
+  border: 1px solid rgba(47, 33, 20, 0.55);
   background:
-    linear-gradient(180deg, rgba(255, 248, 214, 0.48), rgba(228, 211, 170, 0.22)),
-    radial-gradient(circle at 16% 0%, rgba(201, 151, 61, 0.28), transparent 17rem);
+    linear-gradient(180deg, rgba(248, 239, 216, 0.74), rgba(212, 181, 111, 0.24)),
+    repeating-linear-gradient(90deg, rgba(38, 53, 31, 0.033) 0 1px, transparent 1px 18px),
+    repeating-linear-gradient(0deg, rgba(37, 25, 15, 0.022) 0 1px, transparent 1px 11px);
+  box-shadow: inset 0 0 0 6px rgba(255, 248, 224, 0.34);
 }
 
+body.page-fate-of-the-fellowship .fate-hero-plate {
+  display: grid;
+  justify-items: center;
+  gap: clamp(0.55rem, 1vw, 0.85rem);
+  max-width: 43rem;
+  text-align: center;
+}
+
+body.page-fate-of-the-fellowship .fate-hero-pretitle,
+body.page-fate-of-the-fellowship .fate-briefing-label,
+body.page-fate-of-the-fellowship .fate-overview-label,
+body.page-fate-of-the-fellowship .fate-result-seal,
+body.page-fate-of-the-fellowship .fate-player-count,
+body.page-fate-of-the-fellowship .fate-action-button,
 body.page-fate-of-the-fellowship .fate-return-link {
-  justify-self: start;
-  display: inline-flex;
-  align-items: center;
-  min-height: 44px;
-  padding: 0.55rem 0.9rem;
-  border: 1px solid rgba(35, 24, 15, 0.28);
-  border-radius: 999px;
-  background: rgba(18, 35, 22, 0.92);
-  color: #f7edcd;
-  font-size: 0.82rem;
-  font-weight: 700;
+  font-family: "Cinzel", "Cinzel Decorative", Georgia, serif;
   letter-spacing: 0;
-  text-decoration: none;
-  box-shadow: 0 8px 18px rgba(18, 35, 22, 0.22);
 }
 
-body.page-fate-of-the-fellowship .fate-return-link:hover,
-body.page-fate-of-the-fellowship .fate-return-link:focus-visible {
-  background: var(--fate-oxblood);
-  color: #fffaf0;
-}
-
-body.page-fate-of-the-fellowship .fate-kicker {
+body.page-fate-of-the-fellowship .fate-hero-pretitle {
   margin: 0;
-  color: var(--fate-oxblood);
-  font-size: 0.78rem;
-  font-weight: 800;
-  letter-spacing: 0.1em;
+  color: var(--fate-rust);
+  font-size: clamp(0.86rem, 1.4vw, 1.06rem);
+  font-weight: 700;
   text-transform: uppercase;
 }
 
 body.page-fate-of-the-fellowship .fate-ledger h1 {
-  max-width: 12ch;
+  max-width: 13.5ch;
   margin: 0;
-  color: var(--fate-ink);
-  text-wrap: balance;
-  text-shadow: 0 1px 0 rgba(255, 252, 228, 0.58);
+  background: none;
+  color: var(--fate-green);
+  font-family: "Cinzel Decorative", "Cinzel", Georgia, serif;
+  font-size: clamp(2.8rem, 6.2vw, 5.55rem);
+  font-weight: 900;
+  letter-spacing: 0;
+  line-height: 1;
+  text-transform: uppercase;
+  text-shadow: 0 1px 0 rgba(255, 248, 224, 0.7);
+  -webkit-background-clip: border-box;
+  background-clip: border-box;
+  -webkit-text-fill-color: var(--fate-green);
+}
+
+body.page-fate-of-the-fellowship .fate-script-band {
+  width: min(28rem, 100%);
+  margin: 0;
+  padding: 0.32rem 0.55rem 0.38rem;
+  border-top: 1px solid rgba(38, 53, 31, 0.46);
+  border-bottom: 1px solid rgba(38, 53, 31, 0.46);
+  color: rgba(38, 53, 31, 0.72);
+  font-family: "Noto Sans Runic", "IM Fell English SC", Georgia, serif;
+  font-size: clamp(1.05rem, 1.6vw, 1.42rem);
+  letter-spacing: 0.08em;
+  line-height: 1.1;
+  overflow-wrap: anywhere;
+  word-spacing: 0.3rem;
+}
+
+body.page-fate-of-the-fellowship .fate-hero-tagline {
+  max-width: 36rem;
+  margin: 0;
+  color: var(--fate-green);
+  font-family: "Cinzel", Georgia, serif;
+  font-size: clamp(0.82rem, 1.25vw, 1rem);
+  font-weight: 700;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
+body.page-fate-of-the-fellowship .fate-hero-tagline span {
+  color: var(--fate-rust);
+  padding: 0 0.35rem;
 }
 
 body.page-fate-of-the-fellowship .fate-intro {
-  max-width: 68ch;
+  max-width: 35rem;
   color: var(--fate-ink-soft);
-  font-size: 1.04rem;
-  line-height: 1.7;
+  font-family: "IM Fell English", Georgia, serif;
+  font-size: clamp(1.05rem, 1.5vw, 1.24rem);
+  font-style: italic;
+  line-height: 1.45;
+  -webkit-text-fill-color: var(--fate-ink-soft);
 }
 
 body.page-fate-of-the-fellowship .fate-intro p {
   margin: 0;
 }
 
+body.page-fate-of-the-fellowship .fate-return-link,
+body.page-fate-of-the-fellowship .fate-enter-link,
+body.page-fate-of-the-fellowship .fate-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0.58rem 0.9rem;
+  border: 1px solid #2f2114;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #35482a, #15220f);
+  color: #fff7df;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 4px 0 rgba(47, 33, 20, 0.34);
+}
+
+body.page-fate-of-the-fellowship .fate-return-link:visited,
+body.page-fate-of-the-fellowship .fate-enter-link:visited,
+body.page-fate-of-the-fellowship .fate-action-button:visited {
+  color: #fff7df;
+}
+
+body.page-fate-of-the-fellowship .fate-return-link:hover,
+body.page-fate-of-the-fellowship .fate-return-link:focus-visible,
+body.page-fate-of-the-fellowship .fate-enter-link:hover,
+body.page-fate-of-the-fellowship .fate-enter-link:focus-visible,
+body.page-fate-of-the-fellowship .fate-action-button:hover,
+body.page-fate-of-the-fellowship .fate-action-button:focus-visible {
+  background: linear-gradient(180deg, #5b6f3f, #26351f) !important;
+  color: #fff7df !important;
+  border-color: #2f2114;
+  box-shadow: 0 4px 0 rgba(47, 33, 20, 0.38);
+}
+
+body.page-fate-of-the-fellowship .fate-ledger-header > .fate-return-link {
+  position: absolute;
+  top: clamp(0.9rem, 2vw, 1.3rem);
+  right: clamp(0.9rem, 2vw, 1.3rem);
+  z-index: 3;
+}
+
+body.page-fate-of-the-fellowship .fate-enter-link {
+  margin-top: 0.25rem;
+}
+
 body.page-fate-of-the-fellowship .fate-section {
-  position: relative;
-  z-index: 1;
-  padding: clamp(1rem, 2.4vw, 1.6rem);
-  border: 1px solid rgba(75, 53, 36, 0.22);
-  border-radius: 8px;
+  padding: clamp(1.2rem, 2.6vw, 2rem) clamp(1rem, 4.5vw, 4.4rem);
+  border: 1px solid rgba(47, 33, 20, 0.42);
   background:
-    linear-gradient(180deg, rgba(255, 248, 214, 0.55), rgba(228, 211, 170, 0.3)),
-    linear-gradient(90deg, rgba(38, 60, 38, 0.06), transparent 52%);
-  box-shadow: 0 14px 32px rgba(35, 24, 15, 0.12);
+    linear-gradient(180deg, rgba(255, 248, 224, 0.48), rgba(212, 181, 111, 0.18)),
+    repeating-linear-gradient(90deg, rgba(37, 25, 15, 0.026) 0 1px, transparent 1px 14px);
+  box-shadow: inset 0 0 0 4px rgba(255, 248, 224, 0.22);
 }
 
 body.page-fate-of-the-fellowship .fate-section-heading {
   display: grid;
-  gap: 0.3rem;
-  margin-bottom: 1rem;
+  gap: 0.35rem;
+  margin-bottom: 0.85rem;
 }
 
 body.page-fate-of-the-fellowship .fate-section-heading h2 {
   margin: 0;
-  color: var(--fate-forest-dark);
-  font-size: clamp(1.28rem, 2vw, 1.65rem);
+  color: var(--fate-green);
+  font-family: "Cinzel Decorative", "Cinzel", Georgia, serif;
+  font-size: clamp(1.65rem, 3vw, 2.55rem);
+  font-weight: 900;
+  letter-spacing: 0;
+  line-height: 1;
+  text-align: center;
+  text-transform: uppercase;
 }
 
 body.page-fate-of-the-fellowship .fate-section-heading p {
-  max-width: 64ch;
-  margin: 0;
+  max-width: 66ch;
+  margin: 0 auto;
   color: var(--fate-ink-soft);
-  line-height: 1.55;
+  font-family: "IM Fell English", Georgia, serif;
+  font-size: 1.08rem;
+  line-height: 1.45;
+  text-align: center;
+}
+
+body.page-fate-of-the-fellowship .fate-briefing-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(0.8rem, 2vw, 1.2rem);
+}
+
+body.page-fate-of-the-fellowship .fate-callout-box,
+body.page-fate-of-the-fellowship .fate-overview-card,
+body.page-fate-of-the-fellowship .fate-record-card,
+body.page-fate-of-the-fellowship .fate-quest-card,
+body.page-fate-of-the-fellowship .fate-log-card {
+  position: relative;
+  border: 2px solid rgba(47, 33, 20, 0.68);
+  border-radius: 2px;
+  background:
+    linear-gradient(180deg, rgba(255, 248, 224, 0.72), rgba(220, 197, 142, 0.46)),
+    repeating-linear-gradient(0deg, rgba(37, 25, 15, 0.026) 0 1px, transparent 1px 9px);
+  color: var(--fate-ink);
+  box-shadow:
+    inset 0 0 0 3px rgba(199, 154, 69, 0.18),
+    0 8px 16px rgba(74, 50, 31, 0.1);
+}
+
+body.page-fate-of-the-fellowship .fate-callout-box::before,
+body.page-fate-of-the-fellowship .fate-overview-card::before,
+body.page-fate-of-the-fellowship .fate-record-card::before,
+body.page-fate-of-the-fellowship .fate-quest-card::before,
+body.page-fate-of-the-fellowship .fate-log-card::before {
+  position: absolute;
+  inset: 0.38rem;
+  pointer-events: none;
+  content: "";
+  border: 1px solid rgba(95, 65, 36, 0.25);
+}
+
+body.page-fate-of-the-fellowship .fate-briefing-card {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1rem 1.05rem;
+}
+
+body.page-fate-of-the-fellowship .fate-briefing-label {
+  justify-self: start;
+  padding: 0.18rem 0.48rem;
+  border: 1px solid rgba(47, 33, 20, 0.45);
+  background: rgba(38, 53, 31, 0.14);
+  color: var(--fate-green);
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+body.page-fate-of-the-fellowship .fate-briefing-card p,
+body.page-fate-of-the-fellowship .fate-record-card p,
+body.page-fate-of-the-fellowship .fate-quest-card p,
+body.page-fate-of-the-fellowship .fate-log-card p,
+body.page-fate-of-the-fellowship .fate-log-topline time {
+  margin: 0;
+  color: #4a321f;
+  font-family: "IM Fell English", Georgia, serif;
+  font-size: 1.02rem;
+  line-height: 1.42;
+  -webkit-text-fill-color: #4a321f;
 }
 
 body.page-fate-of-the-fellowship .fate-overview-grid,
@@ -2816,78 +2906,92 @@ body.page-fate-of-the-fellowship .fate-card-list,
 body.page-fate-of-the-fellowship .fate-quest-list,
 body.page-fate-of-the-fellowship .fate-log-list {
   display: grid;
-  gap: 0.85rem;
+  gap: 0.72rem;
 }
 
-body.page-fate-of-the-fellowship .fate-overview-grid {
+body.page-fate-of-the-fellowship .fate-stat-strip {
   grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-body.page-fate-of-the-fellowship .fate-card-list {
-  grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
-}
-
-body.page-fate-of-the-fellowship .fate-quest-list {
-  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
-}
-
-body.page-fate-of-the-fellowship .fate-log-list {
-  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
-}
-
-body.page-fate-of-the-fellowship .fate-overview-card,
-body.page-fate-of-the-fellowship .fate-briefing-card,
-body.page-fate-of-the-fellowship .fate-record-card,
-body.page-fate-of-the-fellowship .fate-quest-card,
-body.page-fate-of-the-fellowship .fate-log-card {
-  border: 1px solid rgba(75, 53, 36, 0.2);
-  border-radius: 7px;
-  background:
-    linear-gradient(180deg, rgba(255, 248, 214, 0.72), rgba(226, 204, 151, 0.72)),
-    repeating-linear-gradient(100deg, rgba(35, 24, 15, 0.035) 0 1px, transparent 1px 10px);
-  color: var(--fate-ink);
-  box-shadow: 0 10px 20px rgba(35, 24, 15, 0.1);
 }
 
 body.page-fate-of-the-fellowship .fate-overview-card {
   display: grid;
-  gap: 0.3rem;
-  min-height: 7rem;
-  padding: 1rem;
+  min-height: 6.4rem;
+  padding: 0.92rem;
+  text-align: center;
 }
 
 body.page-fate-of-the-fellowship .fate-overview-label {
   color: var(--fate-ink-soft);
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   font-weight: 700;
   text-transform: uppercase;
 }
 
 body.page-fate-of-the-fellowship .fate-overview-card strong {
   align-self: end;
-  color: var(--fate-forest-dark);
-  font-size: clamp(2rem, 5vw, 3rem);
+  color: var(--fate-green);
+  font-family: "Cinzel Decorative", "Cinzel", Georgia, serif;
+  font-size: clamp(2rem, 4vw, 3.1rem);
   line-height: 1;
 }
 
 body.page-fate-of-the-fellowship .fate-player-split {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.55rem;
-  margin-top: 1rem;
+  justify-content: center;
+  gap: 0.45rem;
+  margin-top: 0.85rem;
 }
 
 body.page-fate-of-the-fellowship .fate-player-count {
-  display: inline-flex;
-  align-items: center;
-  min-height: 36px;
-  padding: 0.35rem 0.7rem;
-  border: 1px solid rgba(38, 60, 38, 0.24);
-  border-radius: 999px;
-  background: rgba(38, 60, 38, 0.12);
-  color: var(--fate-forest-dark);
-  font-size: 0.86rem;
+  min-height: 34px;
+  padding: 0.34rem 0.65rem;
+  border: 1px solid rgba(47, 33, 20, 0.42);
+  background: rgba(38, 53, 31, 0.12);
+  color: var(--fate-green);
+  font-size: 0.82rem;
   font-weight: 700;
+}
+
+body.page-fate-of-the-fellowship .fate-card-list {
+  grid-template-columns: repeat(auto-fit, minmax(10.5rem, 1fr));
+}
+
+body.page-fate-of-the-fellowship .fate-quest-list {
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+}
+
+body.page-fate-of-the-fellowship .fate-log-list {
+  grid-template-columns: minmax(0, 1fr);
+  max-width: 52rem;
+  margin: 0 auto;
+}
+
+body.page-fate-of-the-fellowship .fate-session-separator {
+  display: grid;
+  grid-template-columns: minmax(1rem, 1fr) auto minmax(1rem, 1fr);
+  gap: 0.85rem;
+  align-items: center;
+  min-height: 2.25rem;
+  color: rgba(38, 53, 31, 0.68);
+  font-family: "Noto Sans Runic", "IM Fell English SC", Georgia, serif;
+  font-size: clamp(0.95rem, 1.8vw, 1.2rem);
+  letter-spacing: 0.12em;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+}
+
+body.page-fate-of-the-fellowship .fate-session-separator::before,
+body.page-fate-of-the-fellowship .fate-session-separator::after {
+  display: block;
+  height: 1px;
+  content: "";
+  background: linear-gradient(90deg, transparent, rgba(38, 53, 31, 0.4));
+}
+
+body.page-fate-of-the-fellowship .fate-session-separator::after {
+  background: linear-gradient(90deg, rgba(38, 53, 31, 0.4), transparent);
 }
 
 body.page-fate-of-the-fellowship .fate-record-card,
@@ -2895,7 +2999,7 @@ body.page-fate-of-the-fellowship .fate-quest-card,
 body.page-fate-of-the-fellowship .fate-log-card {
   display: grid;
   align-content: start;
-  gap: 0.65rem;
+  gap: 0.55rem;
   padding: 1rem;
 }
 
@@ -2903,45 +3007,14 @@ body.page-fate-of-the-fellowship .fate-record-card h3,
 body.page-fate-of-the-fellowship .fate-quest-card h3,
 body.page-fate-of-the-fellowship .fate-log-card h3 {
   margin: 0;
-  color: var(--fate-ink);
-  font-size: 1.02rem;
-  line-height: 1.25;
-}
-
-body.page-fate-of-the-fellowship .fate-record-card p,
-body.page-fate-of-the-fellowship .fate-quest-card p,
-body.page-fate-of-the-fellowship .fate-log-card p {
-  margin: 0;
-  color: var(--fate-ink-soft);
-  line-height: 1.48;
-}
-
-body.page-fate-of-the-fellowship .fate-quest-card {
-  position: relative;
-  transform: rotate(-0.35deg);
-  background:
-    linear-gradient(180deg, rgba(250, 238, 198, 0.86), rgba(220, 193, 131, 0.84)),
-    repeating-linear-gradient(90deg, rgba(35, 24, 15, 0.04) 0 1px, transparent 1px 12px);
-}
-
-body.page-fate-of-the-fellowship .fate-quest-card:nth-child(2n) {
-  transform: rotate(0.28deg);
-}
-
-body.page-fate-of-the-fellowship .fate-quest-card::before {
-  position: absolute;
-  top: 0.55rem;
-  right: 0.65rem;
-  width: 0.7rem;
-  height: 0.7rem;
-  border-radius: 50%;
-  content: "";
-  background: var(--fate-brass);
-  box-shadow: 0 1px 2px rgba(35, 24, 15, 0.35);
+  color: var(--fate-green);
+  font-family: "Cinzel", Georgia, serif;
+  font-size: 1.08rem;
+  line-height: 1.15;
 }
 
 body.page-fate-of-the-fellowship .fate-quest-card.is-required {
-  border-color: rgba(124, 39, 37, 0.42);
+  border-color: rgba(142, 47, 36, 0.78);
 }
 
 body.page-fate-of-the-fellowship .fate-log-card {
@@ -2953,81 +3026,62 @@ body.page-fate-of-the-fellowship .fate-log-topline {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
-}
-
-body.page-fate-of-the-fellowship .fate-log-topline time {
-  color: var(--fate-ink-soft);
-  font-size: 0.88rem;
-  font-weight: 700;
+  gap: 0.45rem;
 }
 
 body.page-fate-of-the-fellowship .fate-result-seal {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 4.5rem;
+  min-width: 4rem;
   min-height: 2rem;
-  padding: 0.25rem 0.65rem;
-  border-radius: 999px;
+  padding: 0.22rem 0.62rem;
+  border: 1px solid #2f2114;
+  border-radius: 50%;
   background:
-    radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.18), transparent 32%),
-    var(--fate-wax);
-  color: #fff7e6;
+    radial-gradient(circle at 34% 24%, rgba(255, 248, 224, 0.28), transparent 26%),
+    radial-gradient(circle, var(--fate-rust) 0 52%, #5d2118 54% 100%);
+  color: #fff7df;
   font-size: 0.78rem;
-  font-weight: 800;
+  font-weight: 700;
   text-transform: uppercase;
-  box-shadow:
-    inset 0 -3px 0 rgba(68, 21, 18, 0.28),
-    0 3px 9px rgba(124, 39, 37, 0.28);
+  box-shadow: 0 3px 6px rgba(74, 50, 31, 0.28);
 }
 
 body.page-fate-of-the-fellowship .fate-result-seal.is-loss {
   background:
-    radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.16), transparent 32%),
-    #4b3524;
+    radial-gradient(circle at 34% 24%, rgba(255, 248, 224, 0.18), transparent 26%),
+    radial-gradient(circle, #4a321f 0 52%, #211409 54% 100%);
 }
 
 body.page-fate-of-the-fellowship .fate-empty-log {
-  min-height: 9rem;
+  min-height: 8rem;
   border-style: dashed;
 }
 
 body.page-fate-of-the-fellowship .fate-actions {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 0.75rem;
 }
 
-body.page-fate-of-the-fellowship .fate-action-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 44px;
-  padding: 0.7rem 1rem;
-  border: 1px solid rgba(35, 24, 15, 0.24);
-  border-radius: 999px;
-  background: linear-gradient(135deg, var(--fate-forest), var(--fate-forest-dark));
-  color: #fffaf0;
-  font-weight: 800;
-  text-decoration: none;
-}
-
-body.page-fate-of-the-fellowship .fate-action-button:hover,
-body.page-fate-of-the-fellowship .fate-action-button:focus-visible {
-  background: linear-gradient(135deg, var(--fate-oxblood), var(--fate-wax));
-  color: #fffaf0;
-}
-
 body.page-fate-of-the-fellowship .fate-action-button.is-secondary {
-  background: rgba(255, 248, 214, 0.72);
+  background: rgba(255, 248, 224, 0.68);
   color: var(--fate-ink);
 }
 
 body.page-fate-of-the-fellowship .fate-action-button.is-secondary:hover,
 body.page-fate-of-the-fellowship .fate-action-button.is-secondary:focus-visible {
-  background: var(--fate-brass);
-  color: #1d130b;
+  background: linear-gradient(180deg, #e8d399, #c79a45) !important;
+  color: #1e130b !important;
+}
+
+body.page-fate-of-the-fellowship .fate-bottom-exit {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: center;
 }
 
 body.page-fate-of-the-fellowship .fate-amp::before {
@@ -3035,16 +3089,15 @@ body.page-fate-of-the-fellowship .fate-amp::before {
 }
 
 body.page-fate-of-the-fellowship .fate-log-photo {
-  margin: 1rem 0 0;
+  margin: 0.7rem 0 0;
   aspect-ratio: 16 / 9;
   overflow: hidden;
-  border: 6px solid rgba(255, 248, 214, 0.74);
-  border-radius: 5px;
-  background: rgba(35, 24, 15, 0.12);
+  border: 6px solid rgba(255, 248, 224, 0.78);
+  background: rgba(37, 25, 15, 0.12);
   box-shadow:
-    0 10px 22px rgba(35, 24, 15, 0.22),
-    inset 0 0 0 1px rgba(35, 24, 15, 0.16);
-  transform: rotate(0.4deg);
+    0 10px 20px rgba(74, 50, 31, 0.22),
+    inset 0 0 0 1px rgba(47, 33, 20, 0.26);
+  transform: rotate(0.35deg);
 }
 
 body.page-fate-of-the-fellowship .fate-log-photo-trigger {
@@ -3070,12 +3123,12 @@ body.page-fate-of-the-fellowship .fate-log-photo img {
 
 body.page-fate-of-the-fellowship .fate-log-photo-trigger:hover img,
 body.page-fate-of-the-fellowship .fate-log-photo-trigger:focus-visible img {
-  filter: sepia(0.04) contrast(1.06) brightness(1.04);
+  filter: sepia(0.03) contrast(1.06) brightness(1.04);
   transform: scale(1.015);
 }
 
 body.page-fate-of-the-fellowship .fate-log-photo-trigger:focus-visible {
-  outline: 3px solid rgba(124, 39, 37, 0.76);
+  outline: 3px solid rgba(142, 47, 36, 0.82);
   outline-offset: -3px;
 }
 
@@ -3084,8 +3137,8 @@ body.page-fate-of-the-fellowship .fate-photo-dialog {
   max-width: 96vw;
   max-height: 96vh;
   padding: 0;
-  border: 1px solid rgba(201, 151, 61, 0.44);
-  border-radius: 8px;
+  border: 1px solid rgba(199, 154, 69, 0.48);
+  border-radius: 4px;
   background: #120d08;
   box-shadow: 0 30px 90px rgba(0, 0, 0, 0.72);
 }
@@ -3108,7 +3161,7 @@ body.page-fate-of-the-fellowship .fate-photo-dialog-image {
   width: auto;
   max-width: calc(96vw - 1.5rem);
   max-height: calc(96vh - 1.5rem);
-  border-radius: 5px;
+  border-radius: 3px;
   object-fit: contain;
 }
 
@@ -3123,9 +3176,9 @@ body.page-fate-of-the-fellowship .fate-photo-dialog-close {
   min-width: 44px;
   min-height: 44px;
   padding: 0.45rem 0.75rem;
-  border: 1px solid rgba(255, 248, 214, 0.38);
-  border-radius: 999px;
-  background: rgba(18, 35, 22, 0.92);
+  border: 1px solid rgba(255, 248, 224, 0.42);
+  border-radius: 3px;
+  background: rgba(38, 53, 31, 0.94);
   color: #fffaf0;
   font-weight: 800;
   cursor: pointer;
@@ -3133,1339 +3186,65 @@ body.page-fate-of-the-fellowship .fate-photo-dialog-close {
 
 body.page-fate-of-the-fellowship .fate-photo-dialog-close:hover,
 body.page-fate-of-the-fellowship .fate-photo-dialog-close:focus-visible {
-  background: var(--fate-oxblood);
+  background: var(--fate-rust);
   color: #fffaf0;
 }
 
-html:has(body.page-fate-of-the-fellowship),
-body.page-fate-of-the-fellowship {
-  --fate-ink: #2b1b0d;
-  --fate-ink-soft: #583d22;
-  --fate-parchment: #d9bf7c;
-  --fate-parchment-deep: #9f7738;
-  --fate-brass: #b88a3f;
-  --fate-forest: #20351f;
-  --fate-forest-dark: #0d1b10;
-  --fate-oxblood: #6d2520;
-  --fate-wax: #8e2e25;
-  --fate-charcoal: #100b06;
-  --fate-shadow: rgba(4, 2, 1, 0.72);
-  background:
-    radial-gradient(ellipse at 18% 8%, rgba(194, 150, 73, 0.26), transparent 24rem),
-    radial-gradient(ellipse at 82% 4%, rgba(19, 49, 23, 0.34), transparent 26rem),
-    linear-gradient(90deg, rgba(0, 0, 0, 0.42) 0 2px, transparent 2px 12px),
-    repeating-linear-gradient(90deg, rgba(217, 191, 124, 0.055) 0 1px, transparent 1px 42px),
-    linear-gradient(180deg, #211306 0%, #140c05 42%, #090603 100%);
-  color: var(--fate-ink);
-  scrollbar-color: rgba(184, 138, 63, 0.72) rgba(20, 12, 5, 0.95);
-  scrollbar-width: thin;
-}
+@media (max-width: 900px) {
+  body.page-fate-of-the-fellowship .fate-rulebook-hero,
+  body.page-fate-of-the-fellowship .fate-briefing-grid {
+    grid-template-columns: 1fr;
+  }
 
-html:has(body.page-fate-of-the-fellowship)::-webkit-scrollbar,
-body.page-fate-of-the-fellowship::-webkit-scrollbar {
-  width: 10px;
-}
-
-html:has(body.page-fate-of-the-fellowship)::-webkit-scrollbar-track,
-body.page-fate-of-the-fellowship::-webkit-scrollbar-track {
-  background:
-    linear-gradient(180deg, rgba(20, 12, 5, 0.98), rgba(8, 5, 3, 0.98));
-}
-
-html:has(body.page-fate-of-the-fellowship)::-webkit-scrollbar-thumb,
-body.page-fate-of-the-fellowship::-webkit-scrollbar-thumb {
-  border: 1px solid rgba(20, 12, 5, 0.85);
-  border-radius: 999px;
-  background:
-    linear-gradient(180deg, rgba(231, 205, 132, 0.72), rgba(116, 78, 31, 0.78));
-}
-
-body.page-fate-of-the-fellowship .site-header,
-body.page-fate-of-the-fellowship .site-footer {
-  display: none;
-}
-
-body.page-fate-of-the-fellowship .fate-page {
-  min-height: 100vh;
-  background:
-    radial-gradient(circle at 50% -8%, rgba(184, 138, 63, 0.18), transparent 25rem),
-    linear-gradient(180deg, rgba(10, 27, 16, 0.42), transparent 34rem);
-}
-
-body.page-fate-of-the-fellowship .fate-page::before {
-  background:
-    radial-gradient(ellipse at 22% 18%, transparent 0 18%, rgba(60, 38, 18, 0.18) 18.5% 19%, transparent 19.5%),
-    radial-gradient(ellipse at 76% 22%, transparent 0 15%, rgba(32, 53, 31, 0.2) 15.5% 16%, transparent 16.5%),
-    linear-gradient(28deg, transparent 0 48%, rgba(184, 138, 63, 0.16) 48.2% 48.7%, transparent 49%),
-    linear-gradient(138deg, transparent 0 54%, rgba(184, 138, 63, 0.1) 54.2% 54.7%, transparent 55%);
-  background-size: 38rem 28rem, 34rem 24rem, 100% 100%, 100% 100%;
-  background-position: 4% 2%, 94% 6%, center, center;
-  mix-blend-mode: multiply;
-  opacity: 0.72;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger {
-  border: 0;
-  border-radius: 6px;
-  background:
-    linear-gradient(90deg, rgba(54, 31, 13, 0.92), rgba(27, 15, 7, 0.92)) left / 1.05rem 100% no-repeat,
-    linear-gradient(270deg, rgba(54, 31, 13, 0.88), rgba(27, 15, 7, 0.88)) right / 1.05rem 100% no-repeat,
-    linear-gradient(180deg, rgba(92, 55, 22, 0.82), rgba(35, 20, 9, 0.86)) top / 100% 1.05rem no-repeat,
-    linear-gradient(0deg, rgba(92, 55, 22, 0.78), rgba(35, 20, 9, 0.86)) bottom / 100% 1.05rem no-repeat,
-    radial-gradient(circle at 20% 12%, rgba(255, 244, 198, 0.5), transparent 18rem),
-    linear-gradient(135deg, rgba(216, 190, 128, 0.98), rgba(171, 128, 59, 0.96)),
-    repeating-linear-gradient(0deg, rgba(61, 38, 17, 0.055) 0 1px, transparent 1px 8px);
-  box-shadow:
-    0 38px 110px var(--fate-shadow),
-    inset 0 0 0 1px rgba(237, 213, 147, 0.42),
-    inset 0 0 0 1.05rem rgba(43, 24, 10, 0.24);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger::before,
-body.page-fate-of-the-fellowship .fate-ledger::after {
-  opacity: 0.26;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header {
-  overflow: hidden;
-  border-color: rgba(84, 55, 25, 0.38);
-  background:
-    linear-gradient(90deg, rgba(68, 37, 15, 0.16), transparent 16%, transparent 84%, rgba(68, 37, 15, 0.14)),
-    radial-gradient(circle at 20% 0%, rgba(246, 222, 155, 0.5), transparent 18rem),
-    linear-gradient(180deg, rgba(244, 222, 166, 0.58), rgba(181, 137, 65, 0.2));
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header::after {
-  position: absolute;
-  right: 1.2rem;
-  bottom: 1rem;
-  width: min(24rem, 44%);
-  height: 7rem;
-  pointer-events: none;
-  content: "";
-  background:
-    radial-gradient(ellipse at 20% 70%, transparent 0 16%, rgba(74, 49, 26, 0.18) 17% 18%, transparent 19%),
-    radial-gradient(ellipse at 60% 45%, transparent 0 21%, rgba(32, 53, 31, 0.18) 22% 23%, transparent 24%),
-    linear-gradient(14deg, transparent 0 45%, rgba(74, 49, 26, 0.16) 45.5% 46%, transparent 46.5%);
-  opacity: 0.72;
-}
-
-body.page-fate-of-the-fellowship .fate-return-link {
-  border-color: rgba(214, 189, 117, 0.5);
-  border-radius: 4px;
-  background:
-    linear-gradient(180deg, rgba(36, 56, 33, 0.98), rgba(12, 27, 14, 0.98));
-  color: #efe0ad;
-  font-family: "IM Fell English SC", Georgia, "Times New Roman", serif;
-  letter-spacing: 0.04em;
-}
-
-body.page-fate-of-the-fellowship .fate-kicker {
-  color: #6d2520;
-  font-family: "IM Fell English SC", Georgia, "Times New Roman", serif;
-  letter-spacing: 0.18em;
-}
-
-body.page-fate-of-the-fellowship .fate-notice-strip {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-  max-width: 48rem;
-}
-
-body.page-fate-of-the-fellowship .fate-notice-strip span,
-body.page-fate-of-the-fellowship .fate-briefing-label {
-  display: inline-flex;
-  align-items: center;
-  min-height: 2rem;
-  padding: 0.35rem 0.65rem;
-  border: 1px solid rgba(86, 52, 21, 0.34);
-  border-radius: 3px;
-  background:
-    linear-gradient(180deg, rgba(246, 226, 170, 0.78), rgba(187, 139, 63, 0.42)),
-    repeating-linear-gradient(90deg, rgba(66, 39, 16, 0.08) 0 1px, transparent 1px 8px);
-  color: #442514;
-  font-family: "IM Fell English SC", Georgia, "Times New Roman", serif;
-  font-size: 0.76rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 244, 199, 0.26),
-    0 5px 12px rgba(69, 41, 16, 0.12);
-}
-
-body.page-fate-of-the-fellowship .fate-briefing-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-body.page-fate-of-the-fellowship .fate-briefing-card {
-  display: grid;
-  align-content: start;
-  gap: 0.85rem;
-  min-height: 100%;
-}
-
-body.page-fate-of-the-fellowship .fate-briefing-card p {
-  margin: 0;
-  color: #3d2514;
-  font-family: "IM Fell English", Georgia, "Times New Roman", serif;
-  font-size: clamp(1rem, 1.5vw, 1.16rem);
-  line-height: 1.55;
-  -webkit-text-fill-color: #3d2514;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger h1 {
-  max-width: 12ch;
-  background: none !important;
-  background-image: none !important;
-  background-clip: border-box !important;
-  -webkit-background-clip: border-box !important;
-  -webkit-text-fill-color: #2b1b0d;
-  color: #2b1b0d;
-  font-family: "Uncial Antiqua", "Cinzel Decorative", Georgia, "Times New Roman", serif;
-  font-size: clamp(2.7rem, 7vw, 5.9rem);
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 0.98;
-  text-shadow:
-    0 1px 0 rgba(255, 243, 198, 0.66),
-    0 3px 0 rgba(123, 76, 24, 0.16),
-    0 10px 22px rgba(69, 41, 16, 0.18);
-}
-
-body.page-fate-of-the-fellowship .fate-intro,
-body.page-fate-of-the-fellowship .fate-section-heading p,
-body.page-fate-of-the-fellowship .fate-record-card p,
-body.page-fate-of-the-fellowship .fate-quest-card p,
-body.page-fate-of-the-fellowship .fate-log-card p,
-body.page-fate-of-the-fellowship .fate-log-topline time {
-  color: var(--fate-ink-soft);
-  font-family: "IM Fell English", Georgia, "Times New Roman", serif;
-  -webkit-text-fill-color: currentColor;
-}
-
-body.page-fate-of-the-fellowship .fate-intro p {
-  color: inherit;
-  -webkit-text-fill-color: currentColor;
-}
-
-body.page-fate-of-the-fellowship .fate-section {
-  border-color: rgba(73, 45, 18, 0.32);
-  background:
-    radial-gradient(circle at 10% 0%, rgba(247, 224, 157, 0.36), transparent 14rem),
-    linear-gradient(180deg, rgba(239, 214, 154, 0.7), rgba(181, 137, 65, 0.28)),
-    repeating-linear-gradient(90deg, rgba(54, 31, 13, 0.035) 0 1px, transparent 1px 18px);
-  box-shadow:
-    0 14px 38px rgba(43, 24, 10, 0.16),
-    inset 0 0 0 1px rgba(255, 243, 198, 0.34);
-}
-
-body.page-fate-of-the-fellowship .fate-section-heading h2,
-body.page-fate-of-the-fellowship .fate-record-card h3,
-body.page-fate-of-the-fellowship .fate-quest-card h3,
-body.page-fate-of-the-fellowship .fate-log-card h3 {
-  color: #1f321e;
-  font-family: "Cinzel Decorative", "IM Fell English SC", Georgia, serif;
-  font-weight: 700;
-}
-
-body.page-fate-of-the-fellowship .fate-section-heading h2 {
-  font-size: clamp(1.45rem, 2.4vw, 2.05rem);
-}
-
-body.page-fate-of-the-fellowship .fate-overview-card,
-body.page-fate-of-the-fellowship .fate-briefing-card,
-body.page-fate-of-the-fellowship .fate-record-card,
-body.page-fate-of-the-fellowship .fate-quest-card,
-body.page-fate-of-the-fellowship .fate-log-card {
-  border-color: rgba(73, 45, 18, 0.32);
-  border-radius: 3px;
-  background:
-    radial-gradient(circle at 18% 8%, rgba(255, 240, 187, 0.42), transparent 9rem),
-    linear-gradient(180deg, rgba(239, 217, 161, 0.92), rgba(199, 160, 83, 0.78)),
-    repeating-linear-gradient(101deg, rgba(43, 27, 13, 0.045) 0 1px, transparent 1px 11px);
-  box-shadow:
-    0 10px 22px rgba(44, 25, 10, 0.16),
-    inset 0 0 0 1px rgba(255, 242, 191, 0.26);
-}
-
-body.page-fate-of-the-fellowship .fate-overview-label,
-body.page-fate-of-the-fellowship .fate-player-count {
-  font-family: "IM Fell English SC", Georgia, "Times New Roman", serif;
-  letter-spacing: 0.04em;
-}
-
-body.page-fate-of-the-fellowship .fate-overview-card strong {
-  color: #20351f;
-  font-family: "Cinzel Decorative", "IM Fell English SC", Georgia, serif;
-}
-
-body.page-fate-of-the-fellowship .fate-player-count {
-  border-color: rgba(32, 53, 31, 0.32);
-  border-radius: 4px;
-  background:
-    linear-gradient(180deg, rgba(213, 188, 120, 0.72), rgba(157, 115, 51, 0.32));
-}
-
-body.page-fate-of-the-fellowship .fate-quest-card {
-  border-style: solid;
-  background:
-    linear-gradient(90deg, rgba(91, 50, 20, 0.18), transparent 1.25rem),
-    radial-gradient(circle at 90% 12%, rgba(111, 38, 28, 0.16), transparent 5rem),
-    linear-gradient(180deg, rgba(236, 214, 158, 0.94), rgba(190, 143, 66, 0.82)),
-    repeating-linear-gradient(90deg, rgba(43, 27, 13, 0.05) 0 1px, transparent 1px 12px);
-}
-
-body.page-fate-of-the-fellowship .fate-quest-card::before {
-  top: 0.65rem;
-  right: 0.7rem;
-  width: 0.9rem;
-  height: 0.9rem;
-  background:
-    radial-gradient(circle at 35% 30%, #efd28a 0 18%, #a87931 19% 58%, #5a3415 59% 100%);
-}
-
-body.page-fate-of-the-fellowship .fate-result-seal {
-  min-width: 3.65rem;
-  min-height: 3.65rem;
-  border: 2px solid rgba(255, 230, 171, 0.5);
-  border-radius: 50%;
-  background:
-    radial-gradient(circle at 32% 22%, rgba(255, 240, 196, 0.22), transparent 24%),
-    radial-gradient(circle, #9a3329 0 48%, #6d2520 50% 72%, #4a1712 73% 100%);
-  color: #fff1cf;
-  font-family: Georgia, "Times New Roman", serif;
-  letter-spacing: 0.04em;
-  box-shadow:
-    inset 0 -5px 0 rgba(53, 14, 10, 0.24),
-    0 5px 12px rgba(70, 18, 13, 0.32);
-}
-
-body.page-fate-of-the-fellowship .fate-result-seal.is-loss {
-  background:
-    radial-gradient(circle at 32% 22%, rgba(255, 240, 196, 0.16), transparent 24%),
-    radial-gradient(circle, #554026 0 48%, #352416 50% 72%, #1f140c 73% 100%);
-}
-
-body.page-fate-of-the-fellowship .fate-action-button {
-  border-color: rgba(214, 189, 117, 0.5);
-  border-radius: 4px;
-  background:
-    linear-gradient(180deg, #263f27, #0f2412);
-  color: #fff1cf;
-  font-family: "Palatino Linotype", Palatino, Georgia, serif;
-  letter-spacing: 0.02em;
-}
-
-body.page-fate-of-the-fellowship .fate-action-button:hover,
-body.page-fate-of-the-fellowship .fate-action-button:focus-visible {
-  background: linear-gradient(180deg, #6d2520, #431610);
-}
-
-body.page-fate-of-the-fellowship .fate-action-button.is-secondary {
-  background:
-    linear-gradient(180deg, rgba(239, 214, 154, 0.86), rgba(174, 127, 57, 0.7));
-}
-
-body.page-fate-of-the-fellowship .fate-log-photo {
-  border-color: rgba(239, 214, 154, 0.88);
-  border-radius: 2px;
-  box-shadow:
-    0 12px 26px rgba(43, 24, 10, 0.28),
-    0 0 0 1px rgba(72, 44, 18, 0.28);
-}
-
-body.page-fate-of-the-fellowship {
-  background:
-    radial-gradient(ellipse at 18% 8%, rgba(77, 19, 12, 0.34), transparent 22rem),
-    radial-gradient(ellipse at 86% 18%, rgba(183, 132, 48, 0.12), transparent 28rem),
-    radial-gradient(ellipse at 50% 100%, rgba(15, 35, 18, 0.36), transparent 36rem),
-    linear-gradient(90deg, rgba(255, 226, 151, 0.045) 0 1px, transparent 1px 36px),
-    linear-gradient(180deg, #130806 0%, #090604 46%, #050403 100%);
-}
-
-body.page-fate-of-the-fellowship .fate-page {
-  padding-top: clamp(3rem, 6vw, 5rem);
-  background:
-    radial-gradient(circle at 12% 12%, rgba(220, 187, 111, 0.08), transparent 20rem),
-    radial-gradient(circle at 88% 0%, rgba(84, 19, 14, 0.22), transparent 24rem);
-}
-
-body.page-fate-of-the-fellowship .fate-page .container {
-  width: min(1280px, calc(100vw - 2rem));
-}
-
-body.page-fate-of-the-fellowship .fate-ledger {
-  overflow: hidden;
-  padding: clamp(1.25rem, 2.6vw, 2.4rem);
-  border: 1px solid rgba(218, 190, 120, 0.42);
-  border-radius: 8px;
-  background:
-    radial-gradient(circle at 10% 8%, rgba(255, 244, 207, 0.62), transparent 24rem),
-    radial-gradient(circle at 95% 10%, rgba(108, 36, 23, 0.13), transparent 18rem),
-    linear-gradient(90deg, rgba(40, 20, 9, 0.95), rgba(25, 12, 6, 0.94)) left / 1.05rem 100% no-repeat,
-    linear-gradient(270deg, rgba(40, 20, 9, 0.95), rgba(25, 12, 6, 0.94)) right / 1.05rem 100% no-repeat,
-    linear-gradient(180deg, rgba(68, 35, 14, 0.92), rgba(29, 14, 6, 0.94)) top / 100% 1.05rem no-repeat,
-    linear-gradient(0deg, rgba(68, 35, 14, 0.9), rgba(29, 14, 6, 0.94)) bottom / 100% 1.05rem no-repeat,
-    linear-gradient(135deg, rgba(232, 209, 164, 0.98), rgba(207, 171, 107, 0.98) 46%, rgba(177, 131, 66, 0.98)),
-    repeating-linear-gradient(90deg, rgba(54, 31, 13, 0.045) 0 1px, transparent 1px 18px);
-  box-shadow:
-    0 34px 95px rgba(0, 0, 0, 0.78),
-    inset 0 0 0 1px rgba(255, 244, 198, 0.44),
-    inset 0 0 0 1.05rem rgba(37, 18, 8, 0.22);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger::before {
-  top: -2rem;
-  right: -1.2rem;
-  width: 8.5rem;
-  height: 8.5rem;
-  border: 1px solid rgba(112, 39, 25, 0.2);
-  background:
-    radial-gradient(circle, rgba(157, 45, 35, 0.36) 0 34%, transparent 35% 49%, rgba(88, 31, 20, 0.22) 50% 56%, transparent 57%);
-  opacity: 1;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger::after {
-  right: auto;
-  bottom: -2.4rem;
-  left: -1.4rem;
-  width: 9rem;
-  height: 9rem;
-  border: 1px solid rgba(32, 53, 31, 0.18);
-  background:
-    radial-gradient(circle, rgba(32, 53, 31, 0.22) 0 28%, transparent 29% 47%, rgba(88, 31, 20, 0.18) 48% 55%, transparent 56%);
-  opacity: 1;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header {
-  min-height: clamp(31rem, 52vw, 39rem);
-  padding: clamp(1.4rem, 3vw, 2.4rem);
-  border: 1px solid rgba(77, 49, 24, 0.36);
-  border-radius: 8px;
-  background:
-    radial-gradient(circle at 27% 30%, rgba(255, 245, 210, 0.64), transparent 18rem),
-    linear-gradient(90deg, rgba(66, 34, 15, 0.14), transparent 18%, transparent 82%, rgba(66, 34, 15, 0.14)),
-    linear-gradient(180deg, rgba(240, 220, 181, 0.68), rgba(205, 163, 98, 0.22)),
-    repeating-linear-gradient(0deg, rgba(55, 33, 16, 0.035) 0 1px, transparent 1px 11px);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header::before {
-  position: absolute;
-  right: clamp(1rem, 5vw, 4rem);
-  top: clamp(4.5rem, 10vw, 7rem);
-  width: clamp(16rem, 34vw, 29rem);
-  aspect-ratio: 1;
-  pointer-events: none;
-  content: "";
-  border: clamp(0.5rem, 1vw, 0.8rem) solid rgba(235, 226, 206, 0.72);
-  border-radius: 50%;
-  background:
-    radial-gradient(circle, transparent 0 51%, rgba(214, 189, 117, 0.5) 52% 53%, transparent 54% 62%, rgba(235, 226, 206, 0.28) 63% 64%, transparent 65%),
-    conic-gradient(from -22deg, rgba(255, 255, 255, 0.08), rgba(198, 190, 177, 0.72), rgba(255, 255, 255, 0.1), rgba(198, 190, 177, 0.58), rgba(255, 255, 255, 0.08));
-  filter: drop-shadow(0 0 22px rgba(255, 248, 220, 0.16));
-  opacity: 0.88;
-  mask: radial-gradient(circle, transparent 0 44%, #000 45% 61%, transparent 62%);
-  -webkit-mask: radial-gradient(circle, transparent 0 44%, #000 45% 61%, transparent 62%);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header::after {
-  right: 0;
-  bottom: 0;
-  width: min(34rem, 52%);
-  height: 17rem;
-  background:
-    radial-gradient(ellipse at 24% 72%, transparent 0 15%, rgba(58, 38, 22, 0.18) 16% 17%, transparent 18%),
-    radial-gradient(ellipse at 64% 48%, transparent 0 20%, rgba(32, 53, 31, 0.18) 21% 22%, transparent 23%),
-    linear-gradient(16deg, transparent 0 45%, rgba(58, 38, 22, 0.16) 45.5% 46%, transparent 46.5%),
-    linear-gradient(146deg, transparent 0 58%, rgba(58, 38, 22, 0.12) 58.5% 59%, transparent 59.5%);
-  opacity: 0.85;
-}
-
-body.page-fate-of-the-fellowship .fate-return-link {
-  background:
-    linear-gradient(180deg, rgba(39, 65, 37, 0.98), rgba(13, 30, 15, 0.98));
-  box-shadow:
-    0 9px 18px rgba(19, 34, 17, 0.28),
-    inset 0 0 0 1px rgba(255, 238, 174, 0.14);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header > .fate-return-link {
-  justify-self: end;
-  margin-left: auto;
-  position: relative;
-  z-index: 2;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger h1 {
-  position: relative;
-  z-index: 1;
-  max-width: 11ch;
-  margin-top: clamp(1.2rem, 4vw, 2.3rem);
-  color: #180d06;
-  -webkit-text-fill-color: #180d06;
-  font-size: clamp(3.7rem, 9vw, 8.25rem);
-  line-height: 0.86;
-  text-shadow:
-    0 1px 0 rgba(255, 246, 214, 0.76),
-    0 5px 18px rgba(34, 15, 6, 0.22);
-}
-
-body.page-fate-of-the-fellowship .fate-intro {
-  position: relative;
-  z-index: 1;
-  max-width: 47rem;
-  margin-top: 0.4rem;
-  color: #4b2f19;
-  font-size: clamp(1.03rem, 1.5vw, 1.24rem);
-}
-
-body.page-fate-of-the-fellowship .fate-section {
-  background:
-    radial-gradient(circle at 8% 0%, rgba(255, 242, 200, 0.52), transparent 15rem),
-    linear-gradient(180deg, rgba(235, 211, 166, 0.84), rgba(189, 142, 73, 0.34)),
-    repeating-linear-gradient(90deg, rgba(54, 31, 13, 0.035) 0 1px, transparent 1px 18px);
-}
-
-body.page-fate-of-the-fellowship .fate-section-heading {
-  padding-bottom: 0.65rem;
-  border-bottom: 1px solid rgba(80, 51, 25, 0.22);
-}
-
-body.page-fate-of-the-fellowship .fate-section-heading h2 {
-  letter-spacing: 0;
-}
-
-body.page-fate-of-the-fellowship .fate-overview-card,
-body.page-fate-of-the-fellowship .fate-record-card,
-body.page-fate-of-the-fellowship .fate-quest-card,
-body.page-fate-of-the-fellowship .fate-log-card {
-  background:
-    radial-gradient(circle at 18% 8%, rgba(255, 241, 203, 0.5), transparent 9rem),
-    linear-gradient(180deg, rgba(240, 219, 177, 0.94), rgba(204, 160, 87, 0.78)),
-    repeating-linear-gradient(101deg, rgba(43, 27, 13, 0.045) 0 1px, transparent 1px 11px);
-}
-
-body.page-fate-of-the-fellowship .fate-action-button {
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 238, 174, 0.12),
-    0 8px 18px rgba(17, 31, 16, 0.24);
-}
-
-body.page-fate-of-the-fellowship .fate-bottom-exit {
-  display: flex;
-  justify-content: center;
-  padding: clamp(1rem, 3vw, 2rem) 0 0;
+  body.page-fate-of-the-fellowship .fate-stat-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 768px) {
-  body.page-fate-of-the-fellowship .fate-page {
-    padding: 1rem 0;
-  }
-
   body.page-fate-of-the-fellowship .fate-page .container {
-    width: min(100%, calc(100vw - 1rem));
+    width: min(100vw - 0.75rem, 44rem);
   }
 
   body.page-fate-of-the-fellowship .fate-ledger {
-    padding: 0.75rem;
+    padding: 0.55rem;
   }
 
-  body.page-fate-of-the-fellowship .fate-overview-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  body.page-fate-of-the-fellowship .fate-ledger::before,
+  body.page-fate-of-the-fellowship .fate-ledger::after {
+    display: none;
   }
 
-  body.page-fate-of-the-fellowship .fate-briefing-grid,
-  body.page-fate-of-the-fellowship .fate-log-list {
-    grid-template-columns: 1fr;
+  body.page-fate-of-the-fellowship .fate-rulebook-hero {
+    min-height: auto;
+    padding: 4rem 0.75rem 1.5rem;
   }
-}
 
-@media (max-width: 520px) {
-  body.page-fate-of-the-fellowship .fate-ledger-header,
+  body.page-fate-of-the-fellowship .fate-ledger-header > .fate-return-link {
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+
   body.page-fate-of-the-fellowship .fate-section {
-    padding: 1rem;
+    padding: 1rem 0.75rem;
   }
 
-  body.page-fate-of-the-fellowship .fate-overview-grid,
-  body.page-fate-of-the-fellowship .fate-briefing-grid,
   body.page-fate-of-the-fellowship .fate-card-list,
   body.page-fate-of-the-fellowship .fate-quest-list,
   body.page-fate-of-the-fellowship .fate-log-list {
     grid-template-columns: 1fr;
   }
-
-  body.page-fate-of-the-fellowship .fate-ledger h1 {
-    max-width: 100%;
-  }
-
-  body.page-fate-of-the-fellowship .fate-actions {
-    display: grid;
-  }
-}
-
-/* Fate woodcut art pass */
-body.page-fate-of-the-fellowship {
-  --fate-olive: #77745f;
-  --fate-ochre: #bd9854;
-  --fate-blush: #dfc1ad;
-  --fate-rust: #a85f2c;
-  --fate-paper: #f1e6cf;
-  --fate-ink: #24170d;
-  --fate-ink-soft: #4a321f;
-  background:
-    radial-gradient(ellipse at 12% 8%, rgba(223, 193, 173, 0.15), transparent 24rem),
-    radial-gradient(ellipse at 88% 18%, rgba(119, 116, 95, 0.28), transparent 28rem),
-    radial-gradient(ellipse at 50% 100%, rgba(168, 95, 44, 0.18), transparent 36rem),
-    linear-gradient(180deg, #15100a 0%, #0b0805 58%, #050403 100%);
-}
-
-body.page-fate-of-the-fellowship .fate-page {
-  background:
-    radial-gradient(circle at 50% -12%, rgba(189, 152, 84, 0.18), transparent 26rem),
-    linear-gradient(180deg, rgba(36, 23, 13, 0.16), transparent 34rem);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger {
-  border-color: rgba(189, 152, 84, 0.48);
-  background:
-    linear-gradient(90deg, rgba(119, 116, 95, 0.52), transparent 1.4rem, transparent calc(100% - 1.4rem), rgba(168, 95, 44, 0.36)),
-    radial-gradient(circle at 8% 8%, rgba(255, 249, 232, 0.7), transparent 24rem),
-    linear-gradient(135deg, rgba(241, 230, 207, 0.99), rgba(218, 195, 150, 0.97) 52%, rgba(189, 152, 84, 0.86)),
-    repeating-linear-gradient(90deg, rgba(36, 23, 13, 0.035) 0 1px, transparent 1px 18px);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header {
-  background-image:
-    radial-gradient(ellipse at 33% 64%, rgba(246, 236, 213, 0.96) 0 32%, rgba(246, 236, 213, 0.76) 42%, transparent 63%),
-    linear-gradient(90deg, rgba(119, 116, 95, 0.16), transparent 15%, transparent 82%, rgba(168, 95, 44, 0.16)),
-    linear-gradient(180deg, rgba(241, 230, 207, 0.82), rgba(189, 152, 84, 0.2));
-  background-position: left center, center, center;
-  background-repeat: no-repeat;
-  background-size: 66% 76%, auto, auto;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header::before {
-  border-color: rgba(189, 152, 84, 0.34);
-  background:
-    radial-gradient(circle, transparent 0 51%, rgba(189, 152, 84, 0.36) 52% 53%, transparent 54% 62%, rgba(223, 193, 173, 0.28) 63% 64%, transparent 65%),
-    conic-gradient(from -22deg, rgba(255, 255, 255, 0.04), rgba(189, 152, 84, 0.34), rgba(255, 255, 255, 0.06), rgba(119, 116, 95, 0.28), rgba(255, 255, 255, 0.04));
-}
-
-body.page-fate-of-the-fellowship .fate-notice-strip span:nth-child(1),
-body.page-fate-of-the-fellowship .fate-briefing-card:nth-child(1) .fate-briefing-label {
-  background:
-    linear-gradient(180deg, rgba(223, 193, 173, 0.78), rgba(189, 152, 84, 0.28));
-}
-
-body.page-fate-of-the-fellowship .fate-notice-strip span:nth-child(2),
-body.page-fate-of-the-fellowship .fate-briefing-card:nth-child(2) .fate-briefing-label {
-  background:
-    linear-gradient(180deg, rgba(189, 152, 84, 0.74), rgba(119, 116, 95, 0.24));
-}
-
-body.page-fate-of-the-fellowship .fate-notice-strip span:nth-child(3) {
-  background:
-    linear-gradient(180deg, rgba(119, 116, 95, 0.42), rgba(168, 95, 44, 0.24));
-}
-
-body.page-fate-of-the-fellowship .fate-section,
-body.page-fate-of-the-fellowship .fate-overview-card,
-body.page-fate-of-the-fellowship .fate-briefing-card,
-body.page-fate-of-the-fellowship .fate-record-card,
-body.page-fate-of-the-fellowship .fate-quest-card,
-body.page-fate-of-the-fellowship .fate-log-card {
-  background:
-    radial-gradient(circle at 12% 8%, rgba(255, 249, 232, 0.62), transparent 12rem),
-    linear-gradient(180deg, rgba(241, 230, 207, 0.92), rgba(189, 152, 84, 0.26)),
-    repeating-linear-gradient(90deg, rgba(36, 23, 13, 0.035) 0 1px, transparent 1px 13px);
-}
-
-body.page-fate-of-the-fellowship .fate-section-heading h2,
-body.page-fate-of-the-fellowship .fate-record-card h3,
-body.page-fate-of-the-fellowship .fate-quest-card h3,
-body.page-fate-of-the-fellowship .fate-log-card h3,
-body.page-fate-of-the-fellowship .fate-overview-card strong {
-  color: #27331f;
-}
-
-body.page-fate-of-the-fellowship .fate-briefing-card p,
-body.page-fate-of-the-fellowship .fate-intro,
-body.page-fate-of-the-fellowship .fate-section-heading p,
-body.page-fate-of-the-fellowship .fate-record-card p,
-body.page-fate-of-the-fellowship .fate-quest-card p,
-body.page-fate-of-the-fellowship .fate-log-card p,
-body.page-fate-of-the-fellowship .fate-log-topline time {
-  color: var(--fate-ink-soft);
-  -webkit-text-fill-color: currentColor;
-}
-
-body.page-fate-of-the-fellowship .fate-quest-card::before {
-  background:
-    radial-gradient(circle at 35% 30%, #f4e6bf 0 18%, var(--fate-ochre) 19% 58%, var(--fate-rust) 59% 100%);
-}
-
-body.page-fate-of-the-fellowship .fate-return-link,
-body.page-fate-of-the-fellowship .fate-action-button {
-  background:
-    linear-gradient(180deg, #384532, #172313);
-}
-
-body.page-fate-of-the-fellowship .fate-action-button:hover,
-body.page-fate-of-the-fellowship .fate-action-button:focus-visible,
-body.page-fate-of-the-fellowship .fate-return-link:hover,
-body.page-fate-of-the-fellowship .fate-return-link:focus-visible {
-  background:
-    linear-gradient(180deg, var(--fate-rust), #683218);
-}
-
-/* Keep the Fate background art object-based, not abstract rings or blobs. */
-body.page-fate-of-the-fellowship .fate-ledger::before,
-body.page-fate-of-the-fellowship .fate-ledger::after {
-  display: none;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header {
-  background-image:
-    radial-gradient(ellipse at 32% 64%, rgba(246, 236, 213, 0.97) 0 30%, rgba(246, 236, 213, 0.82) 42%, transparent 64%),
-    linear-gradient(180deg, rgba(241, 230, 207, 0.88), rgba(189, 152, 84, 0.18));
-  background-position: left center, center;
-  background-repeat: no-repeat;
-  background-size: 66% 78%, auto;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header::before,
-body.page-fate-of-the-fellowship .fate-ledger-header::after {
-  display: none;
-}
-
-/* Fate parchment and scrollwork pass: no decorative background images. */
-body.page-fate-of-the-fellowship {
-  --fate-paper: #efe1c2;
-  --fate-paper-light: #f7edda;
-  --fate-frame: #8b6a36;
-  --fate-scroll: #6e4f25;
-  --fate-ink: #211409;
-  --fate-ink-soft: #4b321c;
-  background:
-    linear-gradient(180deg, #17100a 0%, #0b0805 58%, #050403 100%);
-}
-
-body.page-fate-of-the-fellowship .fate-page {
-  background:
-    linear-gradient(180deg, rgba(41, 25, 12, 0.28), transparent 28rem);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger {
-  border-color: rgba(139, 106, 54, 0.58);
-  background:
-    linear-gradient(90deg, rgba(75, 48, 21, 0.42), transparent 1.25rem, transparent calc(100% - 1.25rem), rgba(75, 48, 21, 0.34)),
-    linear-gradient(180deg, rgba(247, 237, 218, 0.96), rgba(218, 190, 132, 0.9)),
-    repeating-linear-gradient(90deg, rgba(33, 20, 9, 0.035) 0 1px, transparent 1px 14px),
-    repeating-linear-gradient(0deg, rgba(33, 20, 9, 0.025) 0 1px, transparent 1px 10px);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header {
-  background-image: none;
-  background:
-    linear-gradient(180deg, rgba(247, 237, 218, 0.94), rgba(226, 199, 144, 0.32)),
-    repeating-linear-gradient(90deg, rgba(33, 20, 9, 0.03) 0 1px, transparent 1px 18px),
-    repeating-linear-gradient(0deg, rgba(33, 20, 9, 0.024) 0 1px, transparent 1px 11px);
-}
-
-body.page-fate-of-the-fellowship .fate-section {
-  position: relative;
-  overflow: hidden;
-  border: 1px solid rgba(110, 79, 37, 0.48);
-  outline: 1px solid rgba(255, 247, 222, 0.36);
-  outline-offset: -8px;
-  background:
-    linear-gradient(180deg, rgba(247, 237, 218, 0.9), rgba(216, 188, 128, 0.32)),
-    repeating-linear-gradient(90deg, rgba(33, 20, 9, 0.028) 0 1px, transparent 1px 13px);
-}
-
-body.page-fate-of-the-fellowship .fate-section::before,
-body.page-fate-of-the-fellowship .fate-section::after {
-  position: absolute;
-  width: 5.5rem;
-  height: 5.5rem;
-  pointer-events: none;
-  content: "";
-  border-color: rgba(110, 79, 37, 0.5);
-  border-style: double;
-  opacity: 0.72;
-}
-
-body.page-fate-of-the-fellowship .fate-section::before {
-  top: 0.8rem;
-  left: 0.8rem;
-  border-width: 3px 0 0 3px;
-  border-top-left-radius: 4rem;
-}
-
-body.page-fate-of-the-fellowship .fate-section::after {
-  right: 0.8rem;
-  bottom: 0.8rem;
-  border-width: 0 3px 3px 0;
-  border-bottom-right-radius: 4rem;
-}
-
-body.page-fate-of-the-fellowship .fate-overview-card,
-body.page-fate-of-the-fellowship .fate-briefing-card,
-body.page-fate-of-the-fellowship .fate-record-card,
-body.page-fate-of-the-fellowship .fate-quest-card,
-body.page-fate-of-the-fellowship .fate-log-card {
-  position: relative;
-  border: 1px solid rgba(110, 79, 37, 0.42);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 247, 222, 0.34),
-    0 10px 22px rgba(49, 30, 12, 0.14);
-  background:
-    linear-gradient(180deg, rgba(248, 239, 220, 0.88), rgba(219, 191, 132, 0.38)),
-    repeating-linear-gradient(90deg, rgba(33, 20, 9, 0.026) 0 1px, transparent 1px 12px);
-}
-
-body.page-fate-of-the-fellowship .fate-overview-card::after,
-body.page-fate-of-the-fellowship .fate-briefing-card::after,
-body.page-fate-of-the-fellowship .fate-record-card::after,
-body.page-fate-of-the-fellowship .fate-quest-card::after,
-body.page-fate-of-the-fellowship .fate-log-card::after {
-  position: absolute;
-  right: 0.65rem;
-  bottom: 0.55rem;
-  width: 1.2rem;
-  height: 1.2rem;
-  pointer-events: none;
-  content: "";
-  border-right: 2px double rgba(110, 79, 37, 0.42);
-  border-bottom: 2px double rgba(110, 79, 37, 0.42);
-  border-bottom-right-radius: 1rem;
-}
-
-body.page-fate-of-the-fellowship .fate-briefing-card p {
-  color: #4a321f;
-  -webkit-text-fill-color: #4a321f;
-}
-
-/* Fate SVG scrollwork borders */
-body.page-fate-of-the-fellowship .fate-ledger-header,
-body.page-fate-of-the-fellowship .fate-section {
-  border: 18px solid transparent;
-  border-image-source: url("/images/fate-of-the-fellowship/scrollwork-section-border.svg");
-  border-image-slice: 34;
-  border-image-width: 18px;
-  border-image-repeat: stretch;
-  outline: none;
-}
-
-body.page-fate-of-the-fellowship .fate-section::before,
-body.page-fate-of-the-fellowship .fate-section::after,
-body.page-fate-of-the-fellowship .fate-overview-card::after,
-body.page-fate-of-the-fellowship .fate-briefing-card::after,
-body.page-fate-of-the-fellowship .fate-record-card::after,
-body.page-fate-of-the-fellowship .fate-quest-card::after,
-body.page-fate-of-the-fellowship .fate-log-card::after {
-  display: none;
-}
-
-body.page-fate-of-the-fellowship .fate-overview-card,
-body.page-fate-of-the-fellowship .fate-briefing-card,
-body.page-fate-of-the-fellowship .fate-record-card,
-body.page-fate-of-the-fellowship .fate-quest-card,
-body.page-fate-of-the-fellowship .fate-log-card {
-  border: 12px solid transparent;
-  border-image-source: url("/images/fate-of-the-fellowship/scrollwork-card-border.svg");
-  border-image-slice: 26;
-  border-image-width: 12px;
-  border-image-repeat: stretch;
-}
-
-/* Fate Middle-earth poster pass */
-body.page-fate-of-the-fellowship {
-  --fate-forest: #26351f;
-  --fate-leaf: #5f7645;
-  --fate-gold: #c69a3e;
-  --fate-rust: #9a5529;
-  --fate-blush: #dfc1ad;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger {
-  border: 22px solid transparent;
-  border-image-source: url("/images/fate-of-the-fellowship/scrollwork-section-border.svg");
-  border-image-slice: 34;
-  border-image-width: 22px;
-  border-image-repeat: stretch;
-  background:
-    linear-gradient(180deg, rgba(248, 240, 221, 0.97), rgba(224, 197, 142, 0.9)),
-    repeating-linear-gradient(90deg, rgba(38, 53, 31, 0.034) 0 1px, transparent 1px 16px),
-    repeating-linear-gradient(0deg, rgba(38, 53, 31, 0.026) 0 1px, transparent 1px 12px);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header {
-  display: grid;
-  justify-items: center;
-  align-content: center;
-  min-height: clamp(32rem, 54vw, 42rem);
-  text-align: center;
-  background:
-    linear-gradient(180deg, rgba(248, 240, 221, 0.94), rgba(225, 200, 148, 0.24)),
-    repeating-linear-gradient(90deg, rgba(38, 53, 31, 0.032) 0 1px, transparent 1px 18px),
-    repeating-linear-gradient(0deg, rgba(38, 53, 31, 0.024) 0 1px, transparent 1px 11px);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header > .fate-return-link {
-  justify-self: end;
-  align-self: start;
-}
-
-body.page-fate-of-the-fellowship .fate-kicker {
-  color: #7a2319;
-  font-size: 0.9rem;
-}
-
-body.page-fate-of-the-fellowship .fate-notice-strip {
-  justify-content: center;
-}
-
-body.page-fate-of-the-fellowship .fate-notice-strip span,
-body.page-fate-of-the-fellowship .fate-briefing-label {
-  border-color: rgba(38, 53, 31, 0.42);
-}
-
-body.page-fate-of-the-fellowship .fate-notice-strip span:nth-child(1),
-body.page-fate-of-the-fellowship .fate-briefing-card:nth-child(1) .fate-briefing-label {
-  background:
-    linear-gradient(180deg, rgba(223, 193, 173, 0.84), rgba(198, 154, 62, 0.22));
-}
-
-body.page-fate-of-the-fellowship .fate-notice-strip span:nth-child(2),
-body.page-fate-of-the-fellowship .fate-briefing-card:nth-child(2) .fate-briefing-label {
-  background:
-    linear-gradient(180deg, rgba(198, 154, 62, 0.72), rgba(95, 118, 69, 0.24));
-}
-
-body.page-fate-of-the-fellowship .fate-notice-strip span:nth-child(3) {
-  background:
-    linear-gradient(180deg, rgba(95, 118, 69, 0.38), rgba(154, 85, 41, 0.24));
-}
-
-body.page-fate-of-the-fellowship .fate-ledger h1 {
-  max-width: 10ch;
-  margin-top: clamp(1.4rem, 3vw, 2rem);
-  color: #160d06;
-  -webkit-text-fill-color: #160d06;
-  font-size: clamp(3.8rem, 8.4vw, 8rem);
-  text-shadow:
-    0 1px 0 rgba(255, 247, 224, 0.78),
-    0 4px 0 rgba(198, 154, 62, 0.16),
-    0 13px 24px rgba(38, 53, 31, 0.22);
-}
-
-body.page-fate-of-the-fellowship .fate-intro {
-  max-width: 44rem;
-  color: #3d2817;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger-header,
-body.page-fate-of-the-fellowship .fate-section {
-  border-width: 24px;
-  border-image-width: 24px;
-  border-image-outset: 0;
-}
-
-body.page-fate-of-the-fellowship .fate-section {
-  padding: clamp(1.65rem, 3vw, 2.4rem);
-}
-
-body.page-fate-of-the-fellowship .fate-overview-card,
-body.page-fate-of-the-fellowship .fate-briefing-card,
-body.page-fate-of-the-fellowship .fate-record-card,
-body.page-fate-of-the-fellowship .fate-quest-card,
-body.page-fate-of-the-fellowship .fate-log-card {
-  border-width: 14px;
-  border-image-width: 14px;
-}
-
-body.page-fate-of-the-fellowship .fate-section-heading {
-  border-bottom-color: rgba(38, 53, 31, 0.24);
-}
-
-body.page-fate-of-the-fellowship .fate-section-heading h2,
-body.page-fate-of-the-fellowship .fate-record-card h3,
-body.page-fate-of-the-fellowship .fate-quest-card h3,
-body.page-fate-of-the-fellowship .fate-log-card h3,
-body.page-fate-of-the-fellowship .fate-overview-card strong {
-  color: var(--fate-forest);
-}
-
-body.page-fate-of-the-fellowship .fate-result-seal {
-  border-color: rgba(198, 154, 62, 0.7);
-  background:
-    radial-gradient(circle at 32% 22%, rgba(255, 240, 196, 0.22), transparent 24%),
-    radial-gradient(circle, #9a5529 0 48%, #723417 50% 72%, #3b1b0c 73% 100%);
-}
-
-/* Fate hero simplification */
-body.page-fate-of-the-fellowship .fate-ledger-header {
-  gap: clamp(0.8rem, 1.8vw, 1.35rem);
-  padding: clamp(2rem, 5vw, 4.25rem);
-  background:
-    linear-gradient(180deg, rgba(248, 240, 221, 0.96), rgba(232, 207, 155, 0.25)),
-    repeating-linear-gradient(90deg, rgba(38, 53, 31, 0.026) 0 1px, transparent 1px 18px),
-    repeating-linear-gradient(0deg, rgba(38, 53, 31, 0.02) 0 1px, transparent 1px 11px);
-}
-
-body.page-fate-of-the-fellowship .fate-notice-strip {
-  display: none;
-}
-
-body.page-fate-of-the-fellowship .fate-title-divider {
-  width: min(48rem, 72%);
-  height: auto;
-  opacity: 0.95;
-}
-
-body.page-fate-of-the-fellowship .fate-title-divider.is-lower {
-  transform: rotate(180deg);
-}
-
-body.page-fate-of-the-fellowship .fate-ledger h1 {
-  margin: 0;
-}
-
-/* Fate Kenney fantasy UI asset pass */
-body.page-fate-of-the-fellowship {
-  --fate-kenney-frame-hero: url("/images/fate-of-the-fellowship/kenney/frame-hero-gold.png");
-  --fate-kenney-frame-section: url("/images/fate-of-the-fellowship/kenney/frame-section-gold.png");
-  --fate-kenney-frame-card: url("/images/fate-of-the-fellowship/kenney/frame-card-gold.png");
-  --fate-kenney-panel-hero: url("/images/fate-of-the-fellowship/kenney/panel-hero-parchment.png");
-  --fate-kenney-panel-card: url("/images/fate-of-the-fellowship/kenney/panel-card-parchment.png");
-  --fate-kenney-divider-green: url("/images/fate-of-the-fellowship/kenney/divider-green.png");
-  --fate-kenney-divider-gold: url("/images/fate-of-the-fellowship/kenney/divider-gold.png");
-}
-
-body.page-fate-of-the-fellowship .fate-page {
-  background:
-    linear-gradient(180deg, #140b06 0%, #241207 46%, #100906 100%);
-}
-
-body.page-fate-of-the-fellowship .fate-page::before,
-body.page-fate-of-the-fellowship .fate-ledger::before,
-body.page-fate-of-the-fellowship .fate-ledger::after {
-  display: none;
-}
-
-body.page-fate-of-the-fellowship .fate-page .container {
-  max-width: 1320px;
-}
-
-body.page-fate-of-the-fellowship .fate-ledger {
-  gap: clamp(1.25rem, 2.5vw, 2rem);
-  padding: 0;
-  border: 0;
-  border-image-source: none;
-  background: transparent;
-  box-shadow: none;
-}
-
-body.page-fate-of-the-fellowship .fate-kenney-hero {
-  position: relative;
-  isolation: isolate;
-  display: grid;
-  min-height: clamp(30rem, 48vw, 38rem);
-  padding: clamp(2.5rem, 5vw, 4rem) clamp(1rem, 4vw, 4rem);
-  overflow: hidden;
-  place-items: center;
-  border: 0;
-  border-image-source: none;
-  background:
-    radial-gradient(circle at 50% 38%, rgba(80, 104, 59, 0.26), transparent 30rem),
-    radial-gradient(circle at 16% 72%, rgba(154, 85, 41, 0.28), transparent 18rem),
-    linear-gradient(135deg, #160c06 0%, #2a1709 42%, #0d0906 100%);
-  box-shadow:
-    inset 0 0 0 1px rgba(212, 166, 72, 0.18),
-    inset 0 0 80px rgba(0, 0, 0, 0.46);
-}
-
-body.page-fate-of-the-fellowship .fate-kenney-hero::before,
-body.page-fate-of-the-fellowship .fate-kenney-hero::after {
-  position: absolute;
-  inset: clamp(1rem, 2vw, 1.6rem);
-  z-index: 0;
-  pointer-events: none;
-  content: "";
-  border: 26px solid transparent;
-  border-image-source: var(--fate-kenney-frame-section);
-  border-image-slice: 32;
-  border-image-width: 26px;
-  border-image-repeat: stretch;
-  image-rendering: pixelated;
-  opacity: 0.42;
-}
-
-body.page-fate-of-the-fellowship .fate-kenney-hero::after {
-  inset: clamp(2.2rem, 4vw, 3.4rem);
-  border-image-source: var(--fate-kenney-frame-card);
-  opacity: 0.24;
-}
-
-body.page-fate-of-the-fellowship .fate-hero-panel {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  width: min(52rem, 88%);
-  padding: clamp(1.8rem, 3.5vw, 3rem) clamp(1.25rem, 4vw, 3.5rem);
-  border: 30px solid transparent;
-  border-image-source: var(--fate-kenney-frame-hero);
-  border-image-slice: 32 fill;
-  border-image-width: 30px;
-  border-image-repeat: stretch;
-  background:
-    radial-gradient(circle at 50% 22%, rgba(255, 236, 178, 0.36), transparent 22rem),
-    linear-gradient(180deg, rgba(236, 205, 136, 0.98), rgba(182, 126, 53, 0.9));
-  box-shadow:
-    0 24px 44px rgba(0, 0, 0, 0.42),
-    inset 0 0 0 1px rgba(79, 48, 19, 0.46);
-  image-rendering: pixelated;
-  text-align: center;
-  justify-items: center;
-}
-
-body.page-fate-of-the-fellowship .fate-hero-panel::before {
-  position: absolute;
-  inset: 1.4rem;
-  pointer-events: none;
-  content: "";
-  border: 16px solid transparent;
-  border-image-source: var(--fate-kenney-frame-card);
-  border-image-slice: 32;
-  border-image-width: 16px;
-  border-image-repeat: stretch;
-  opacity: 0.35;
-}
-
-body.page-fate-of-the-fellowship .fate-kenney-divider {
-  position: relative;
-  z-index: 1;
-  width: min(22rem, 78%);
-  height: auto;
-  margin-bottom: clamp(0.55rem, 1.1vw, 0.85rem);
-  image-rendering: pixelated;
-}
-
-body.page-fate-of-the-fellowship .fate-kenney-divider.is-lower {
-  width: min(28rem, 84%);
-  margin-top: clamp(1rem, 1.9vw, 1.5rem);
-  margin-bottom: 0;
-}
-
-body.page-fate-of-the-fellowship .fate-hero-pretitle {
-  position: relative;
-  z-index: 1;
-  margin: 0 0 0.45rem;
-  color: #38240e;
-  font-family: "Cinzel Decorative", Georgia, serif;
-  font-size: clamp(0.82rem, 1.45vw, 1.22rem);
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  line-height: 1.3;
-  text-transform: uppercase;
-  text-shadow: 0 1px 0 rgba(255, 234, 181, 0.68);
-}
-
-body.page-fate-of-the-fellowship .fate-kenney-hero h1 {
-  position: relative;
-  z-index: 1;
-  max-width: 13ch;
-  margin: 0;
-  color: #261405;
-  font-family: "Uncial Antiqua", "Cinzel Decorative", Georgia, serif;
-  font-size: clamp(2.75rem, 5.9vw, 5.35rem);
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 0.94;
-  text-shadow:
-    0 1px 0 rgba(255, 232, 174, 0.75),
-    0 9px 16px rgba(80, 44, 14, 0.2);
-  -webkit-text-fill-color: #261405;
-}
-
-body.page-fate-of-the-fellowship .fate-hero-tagline {
-  position: relative;
-  z-index: 1;
-  max-width: 44rem;
-  margin: clamp(0.65rem, 1.2vw, 0.95rem) 0 0;
-  color: #30401f;
-  font-family: "Cinzel Decorative", Georgia, serif;
-  font-size: clamp(0.78rem, 1.25vw, 1.08rem);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  line-height: 1.55;
-  text-transform: uppercase;
-}
-
-body.page-fate-of-the-fellowship .fate-hero-tagline span {
-  color: #8f551f;
-  padding: 0 0.42rem;
-}
-
-body.page-fate-of-the-fellowship .fate-kenney-hero .fate-intro {
-  position: relative;
-  z-index: 1;
-  max-width: 36rem;
-  margin-top: clamp(0.85rem, 1.7vw, 1.2rem);
-  color: #34210d;
-  font-family: "IM Fell English", Georgia, serif;
-  font-size: clamp(1rem, 1.5vw, 1.22rem);
-  font-style: italic;
-  line-height: 1.48;
-  -webkit-text-fill-color: #34210d;
-}
-
-body.page-fate-of-the-fellowship .fate-kenney-hero > .fate-return-link {
-  position: absolute;
-  top: clamp(1.4rem, 3vw, 2.35rem);
-  right: clamp(1.4rem, 3vw, 2.35rem);
-  z-index: 3;
-  border: 12px solid transparent;
-  border-image-source: var(--fate-kenney-frame-card);
-  border-image-slice: 32 fill;
-  border-image-width: 12px;
-  border-image-repeat: stretch;
-  color: #f3dfaa;
-  background: rgba(48, 64, 31, 0.84);
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.24);
-  image-rendering: pixelated;
-}
-
-body.page-fate-of-the-fellowship .fate-enter-link,
-body.page-fate-of-the-fellowship .fate-action-button,
-body.page-fate-of-the-fellowship .fate-bottom-exit .fate-return-link {
-  position: relative;
-  z-index: 1;
-  border: 16px solid transparent;
-  border-image-source: var(--fate-kenney-frame-card);
-  border-image-slice: 32 fill;
-  border-image-width: 16px;
-  border-image-repeat: stretch;
-  color: #f7e6b5;
-  background: linear-gradient(180deg, rgba(65, 88, 42, 0.98), rgba(35, 55, 28, 0.98));
-  image-rendering: pixelated;
-}
-
-body.page-fate-of-the-fellowship .fate-enter-link {
-  min-width: min(19rem, 100%);
-  min-height: 3.45rem;
-  margin-top: clamp(0.95rem, 1.9vw, 1.45rem);
-}
-
-body.page-fate-of-the-fellowship .fate-section {
-  border: 28px solid transparent;
-  border-image-source: var(--fate-kenney-frame-section);
-  border-image-slice: 32 fill;
-  border-image-width: 28px;
-  border-image-repeat: stretch;
-  background:
-    radial-gradient(circle at 50% 0%, rgba(255, 238, 185, 0.2), transparent 28rem),
-    linear-gradient(180deg, rgba(237, 214, 160, 0.94), rgba(190, 139, 64, 0.6));
-  image-rendering: pixelated;
-}
-
-body.page-fate-of-the-fellowship .fate-section-heading {
-  position: relative;
-  padding-bottom: 1.1rem;
-  border-bottom: 0;
-}
-
-body.page-fate-of-the-fellowship .fate-section-heading::after {
-  display: block;
-  width: min(24rem, 100%);
-  height: 28px;
-  margin-top: 0.85rem;
-  content: "";
-  background: var(--fate-kenney-divider-green) center / contain no-repeat;
-  image-rendering: pixelated;
-}
-
-body.page-fate-of-the-fellowship .fate-overview-card,
-body.page-fate-of-the-fellowship .fate-briefing-card,
-body.page-fate-of-the-fellowship .fate-record-card,
-body.page-fate-of-the-fellowship .fate-quest-card,
-body.page-fate-of-the-fellowship .fate-log-card {
-  border: 20px solid transparent;
-  border-image-source: var(--fate-kenney-frame-card);
-  border-image-slice: 32 fill;
-  border-image-width: 20px;
-  border-image-repeat: stretch;
-  background:
-    linear-gradient(180deg, rgba(238, 218, 171, 0.96), rgba(199, 151, 78, 0.58));
-  image-rendering: pixelated;
-}
-
-body.page-fate-of-the-fellowship .fate-briefing-label,
-body.page-fate-of-the-fellowship .fate-result-seal,
-body.page-fate-of-the-fellowship .fate-player-count {
-  border: 12px solid transparent;
-  border-image-source: var(--fate-kenney-frame-card);
-  border-image-slice: 32 fill;
-  border-image-width: 12px;
-  border-image-repeat: stretch;
-  image-rendering: pixelated;
-}
-
-body.page-fate-of-the-fellowship .fate-log-photo {
-  border: 18px solid transparent;
-  border-image-source: var(--fate-kenney-frame-card);
-  border-image-slice: 32 fill;
-  border-image-width: 18px;
-  border-image-repeat: stretch;
-  image-rendering: pixelated;
-}
-
-@media (max-width: 768px) {
-  body.page-fate-of-the-fellowship .fate-kenney-hero {
-    min-height: clamp(35rem, 130vw, 43rem);
-    padding: 4.5rem 0.75rem 2rem;
-  }
-
-  body.page-fate-of-the-fellowship .fate-kenney-hero::before,
-  body.page-fate-of-the-fellowship .fate-kenney-hero::after {
-    inset: 0.65rem;
-    border-width: 18px;
-    border-image-width: 18px;
-  }
-
-  body.page-fate-of-the-fellowship .fate-hero-panel {
-    width: min(25rem, 96%);
-    padding: 2rem 1rem;
-    border-width: 24px;
-    border-image-width: 24px;
-  }
-
-  body.page-fate-of-the-fellowship .fate-kenney-divider {
-    width: min(19rem, 84%);
-  }
-
-  body.page-fate-of-the-fellowship .fate-kenney-divider.is-lower {
-    width: min(21rem, 88%);
-  }
-
-  body.page-fate-of-the-fellowship .fate-kenney-hero > .fate-return-link {
-    top: 0.9rem;
-    right: 0.85rem;
-  }
 }
 
 @media (max-width: 520px) {
-  body.page-fate-of-the-fellowship .fate-hero-panel::before {
-    display: none;
+  body.page-fate-of-the-fellowship .fate-stat-strip {
+    grid-template-columns: 1fr;
   }
 
-  body.page-fate-of-the-fellowship .fate-hero-tagline {
-    max-width: 17rem;
+  body.page-fate-of-the-fellowship .fate-script-band {
+    font-size: 1.05rem;
+    letter-spacing: 0.04em;
+    word-spacing: 0.12rem;
   }
+
 }

--- a/tests/fate-of-the-fellowship-tracker.test.js
+++ b/tests/fate-of-the-fellowship-tracker.test.js
@@ -24,20 +24,6 @@ const heroesPath = path.join(root, 'data', 'fate-of-the-fellowship', 'heroes.yam
 const objectivesPath = path.join(root, 'data', 'fate-of-the-fellowship', 'objectives.yaml');
 const sessionsDir = path.join(root, 'data', 'fate-of-the-fellowship', 'sessions');
 const sessionPhotosDir = path.join(root, 'static', 'images', 'fate-of-the-fellowship', 'session-photos');
-const sectionBorderPath = path.join(root, 'static', 'images', 'fate-of-the-fellowship', 'scrollwork-section-border.svg');
-const cardBorderPath = path.join(root, 'static', 'images', 'fate-of-the-fellowship', 'scrollwork-card-border.svg');
-const titleDividerPath = path.join(root, 'static', 'images', 'fate-of-the-fellowship', 'scrollwork-title-divider.svg');
-const kenneyAssetsDir = path.join(root, 'static', 'images', 'fate-of-the-fellowship', 'kenney');
-const kenneyNoticePath = path.join(kenneyAssetsDir, 'KENNEY-FANTASY-UI-BORDERS-NOTICE.txt');
-const kenneyRequiredAssetPaths = [
-  'frame-hero-gold.png',
-  'frame-section-gold.png',
-  'frame-card-gold.png',
-  'panel-hero-parchment.png',
-  'panel-card-parchment.png',
-  'divider-green.png',
-  'divider-gold.png',
-].map((file) => path.join(kenneyAssetsDir, file));
 const docsPath = path.join(root, 'docs', 'fate-of-the-fellowship-tracker.md');
 const planPath = path.join(root, 'docs', 'fate-of-the-fellowship-tracker-plan.md');
 const readmePath = path.join(root, 'README.md');
@@ -479,11 +465,6 @@ async function main() {
     objectivesPath,
     sessionsDir,
     sessionPhotosDir,
-    sectionBorderPath,
-    cardBorderPath,
-    titleDividerPath,
-    kenneyNoticePath,
-    ...kenneyRequiredAssetPaths,
     docsPath,
     planPath,
     customCssPath,
@@ -717,20 +698,19 @@ async function main() {
 
     [
       '<h1>Fate of the Fellowship</h1>',
-      'fate-kenney-hero',
-      'fate-hero-panel',
-      'The innkeeper\'s record of',
-      'divider-gold.png',
-      'divider-green.png',
+      'fate-rulebook-hero',
+      'fate-hero-plate',
+      'A field record for',
+      'fate-script-band',
       'Heroes called',
       'Quests assigned',
       'Tales worth keeping',
-      'Enter the ledger',
-      'Overview',
+      'Read the record',
+      'The road so far',
       'Fellowship record',
       'Quest record',
       'Session log',
-      'Add a tale to the ledger',
+      'Add a tale to the record',
       'Empty boasts can wait outside with the ponies.',
       'fewer second breakfasts',
       'Destroy the One Ring',
@@ -781,6 +761,7 @@ async function main() {
       ].forEach((snippet) => {
         assert(emptyRendered.includes(snippet) || emptyText.includes(snippet), `Rendered empty Fate page is missing expected text: ${snippet}`, errors);
       });
+      assert(!emptyRendered.includes('fate-session-separator'), 'Rendered empty Fate page should not include session separators', errors);
 
       [
         'Legolas 0 journeys',
@@ -860,9 +841,12 @@ async function main() {
         'data-fate-lightbox-src',
         'fate-photo-dialog',
         'fate-photo-dialog-image',
+        'fate-session-separator',
       ].forEach((snippet) => {
         assert(populated.includes(snippet), `Rendered populated Fate page is missing expected image markup: ${snippet}`, errors);
       });
+      const separatorCount = (populated.match(/fate-session-separator/g) || []).length;
+      assert(separatorCount === 2, `Rendered populated Fate page should include separators between three sessions, found ${separatorCount}`, errors);
 
       const newestIndex = populatedText.indexOf('June 12, 2026');
       const middleIndex = populatedText.indexOf('June 1, 2026');
@@ -917,17 +901,18 @@ async function main() {
       'body.page-fate-of-the-fellowship .fate-page',
       'body.page-fate-of-the-fellowship .fate-ledger',
       'body.page-fate-of-the-fellowship .fate-section',
-      'body.page-fate-of-the-fellowship .fate-kenney-hero',
-      'body.page-fate-of-the-fellowship .fate-hero-panel',
-      'body.page-fate-of-the-fellowship .fate-kenney-divider',
+      'body.page-fate-of-the-fellowship .fate-rulebook-hero',
+      'body.page-fate-of-the-fellowship .fate-hero-plate',
+      'body.page-fate-of-the-fellowship .fate-script-band',
       'body.page-fate-of-the-fellowship .fate-enter-link',
-      'body.page-fate-of-the-fellowship .fate-title-divider',
       'body.page-fate-of-the-fellowship .fate-briefing-grid',
       'body.page-fate-of-the-fellowship .fate-briefing-card',
+      'body.page-fate-of-the-fellowship .fate-callout-box',
       'body.page-fate-of-the-fellowship .fate-overview-grid',
       'body.page-fate-of-the-fellowship .fate-card-list',
       'body.page-fate-of-the-fellowship .fate-quest-list',
       'body.page-fate-of-the-fellowship .fate-log-list',
+      'body.page-fate-of-the-fellowship .fate-session-separator',
       'body.page-fate-of-the-fellowship .fate-quest-card',
       'body.page-fate-of-the-fellowship .fate-result-seal',
       'body.page-fate-of-the-fellowship .fate-log-photo',
@@ -939,37 +924,37 @@ async function main() {
       'display: none',
       '@media (max-width: 768px)',
       '@media (max-width: 520px)',
-      'parchment',
+      'rulebook redesign',
       'quest',
-      'wax',
-      'brass',
-      '--fate-olive: #77745f',
-      '--fate-ochre: #bd9854',
-      '--fate-blush: #dfc1ad',
-      '--fate-rust: #a85f2c',
-      'Fate parchment and scrollwork pass: no decorative background images.',
-      'Fate SVG scrollwork borders',
-      'Fate Kenney fantasy UI asset pass',
-      '/images/fate-of-the-fellowship/scrollwork-section-border.svg',
-      '/images/fate-of-the-fellowship/scrollwork-card-border.svg',
-      '/images/fate-of-the-fellowship/kenney/frame-hero-gold.png',
-      '/images/fate-of-the-fellowship/kenney/frame-section-gold.png',
-      '/images/fate-of-the-fellowship/kenney/frame-card-gold.png',
-      '/images/fate-of-the-fellowship/kenney/divider-green.png',
-      'image-rendering: pixelated',
-      'border-image-source',
-      '--fate-leaf: #5f7645',
-      '--fate-gold: #c69a3e',
-      'background-image: none',
+      'parchment',
+      '--fate-green: #26351f',
+      '--fate-paper: #efe0b7',
+      '--fate-gold: #c79a45',
+      '--fate-rust: #8e2f24',
       'body.page-fate-of-the-fellowship .fate-ledger::before',
-      'Uncial Antiqua',
       'Cinzel Decorative',
       'IM Fell English',
-      'background-image: none',
-      '-webkit-text-fill-color: #2b1b0d',
-      'body.page-fate-of-the-fellowship .site-header::after',
+      'Noto Sans Runic',
+      'background: linear-gradient(180deg, #5b6f3f, #26351f) !important;',
+      'background: none',
+      '-webkit-text-fill-color: var(--fate-green)',
+      'body.page-fate-of-the-fellowship .fate-section-heading h2',
+      'text-transform: uppercase',
     ].forEach((snippet) => {
       assert(customCss.includes(snippet), `Fate visual CSS is missing expected scoped hook: ${snippet}`, errors);
+    });
+
+    [
+      'rulebook-border-rail.svg',
+      'rulebook-section-divider.svg',
+      'rulebook-side-ornament.svg',
+      'rulebook-map-inset.svg',
+      'rulebook-token-icons.svg',
+      'fate-border-rail',
+      'fate-section-divider',
+      'fate-map-inset',
+    ].forEach((snippet) => {
+      assert(!customCss.includes(snippet), `Fate visual CSS should not reference removed overlapping decoration: ${snippet}`, errors);
     });
 
     const fateSelectorMatches = customCss.match(/(^|\n)([^\n{}]*\.fate-[^\n{}]*)\{/g) || [];
@@ -992,31 +977,26 @@ async function main() {
 
     const { chromium } = await import('playwright');
     const renderedPage = fs.readFileSync(renderedPagePath, 'utf8');
-    const sectionBorder = fs.readFileSync(sectionBorderPath, 'utf8');
-    const cardBorder = fs.readFileSync(cardBorderPath, 'utf8');
-    const titleDivider = fs.readFileSync(titleDividerPath, 'utf8');
-    const kenneyNotice = fs.readFileSync(kenneyNoticePath, 'utf8');
-    ['.leaf', '.flower', '.gold', '.vine', '#3e5a31'].forEach((snippet) => {
-      assert(sectionBorder.includes(snippet), `Fate section scrollwork border should include ornament layer: ${snippet}`, errors);
-    });
-    ['.leaf', '.dot', '.vine', '#3e5a31'].forEach((snippet) => {
-      assert(cardBorder.includes(snippet), `Fate card scrollwork border should include ornament layer: ${snippet}`, errors);
-    });
-    ['.vine', '.leaf', '#26351f', '#5f7645'].forEach((snippet) => {
-      assert(titleDivider.includes(snippet), `Fate title divider should include green vine ornament: ${snippet}`, errors);
-    });
-    ['Kenney Fantasy UI Borders', 'https://kenney.nl/assets/fantasy-ui-borders', 'Creative Commons CC0'].forEach((snippet) => {
-      assert(kenneyNotice.includes(snippet), `Fate Kenney asset notice should include provenance: ${snippet}`, errors);
-    });
-    kenneyRequiredAssetPaths.forEach((assetPath) => {
-      assert(fs.existsSync(assetPath), `Fate Kenney asset is missing: ${assetPath}`, errors);
-    });
     assert(
-      renderedPage.includes('fonts.googleapis.com/css2?family=Cinzel+Decorative') &&
-        renderedPage.includes('family=Uncial+Antiqua'),
-      'Fate rendered page should load the page-specific Tolkien-inspired font families',
+      renderedPage.includes('fonts.googleapis.com/css2?family=Cinzel') &&
+        renderedPage.includes('family=Cinzel+Decorative') &&
+        renderedPage.includes('family=IM+Fell+English') &&
+        renderedPage.includes('family=Noto+Sans+Runic'),
+      'Fate rendered page should load the page-specific rulebook font families',
       errors
     );
+    [
+      'rulebook-border-rail.svg',
+      'rulebook-section-divider.svg',
+      'rulebook-side-ornament.svg',
+      'rulebook-map-inset.svg',
+      'rulebook-token-icons.svg',
+      'fate-border-rail',
+      'fate-section-divider',
+      'fate-map-inset',
+    ].forEach((snippet) => {
+      assert(!renderedPage.includes(snippet), `Fate rendered page should not include removed overlapping decoration: ${snippet}`, errors);
+    });
     const customCss = fs.readFileSync(customCssPath, 'utf8');
     const fixtureImageFileUrl = pathToFileURL(path.join(root, 'static', TEMP_FIXTURE_IMAGE_PATH.replace(/^\//, ''))).href;
     const browserHtml = renderedPage
@@ -1042,7 +1022,6 @@ async function main() {
           const doc = document.documentElement;
           const fatePage = document.querySelector('.fate-page');
           const header = document.querySelector('.fate-ledger-header');
-          const heroPanel = document.querySelector('.fate-hero-panel');
           const topExit = document.querySelector('.fate-ledger-header > .fate-return-link');
           const briefingCopy = document.querySelector('.fate-briefing-card p');
           const styles = fatePage ? getComputedStyle(fatePage) : null;
@@ -1058,17 +1037,13 @@ async function main() {
             h1FontFamily: getComputedStyle(document.querySelector('.fate-ledger h1')).fontFamily,
             h1TextFillColor: getComputedStyle(document.querySelector('.fate-ledger h1')).webkitTextFillColor,
             headerBackgroundImage: getComputedStyle(document.querySelector('.fate-ledger-header')).backgroundImage,
-            kenneyHeroCount: document.querySelectorAll('.fate-kenney-hero').length,
-            heroPanelBorderImageSource: heroPanel ? getComputedStyle(heroPanel).borderImageSource : '',
-            heroPanelImageRendering: heroPanel ? getComputedStyle(heroPanel).imageRendering : '',
-            kenneyDividerCount: document.querySelectorAll('.fate-kenney-divider').length,
+            rulebookHeroCount: document.querySelectorAll('.fate-rulebook-hero').length,
+            heroPlateCount: document.querySelectorAll('.fate-hero-plate').length,
+            scriptBandCount: document.querySelectorAll('.fate-script-band[aria-hidden="true"]').length,
+            calloutCount: document.querySelectorAll('.fate-callout-box').length,
+            separatorCount: document.querySelectorAll('.fate-session-separator').length,
             posterArtCount: document.querySelectorAll('.fate-poster-art').length,
-            sectionBorderImageSource: getComputedStyle(document.querySelector('.fate-section')).borderImageSource,
-            cardBorderImageSource: getComputedStyle(document.querySelector('.fate-briefing-card')).borderImageSource,
             ledgerBeforeDisplay: getComputedStyle(document.querySelector('.fate-ledger'), '::before').display,
-            sectionBeforeDisplay: getComputedStyle(document.querySelector('.fate-section'), '::before').display,
-            ledgerHeaderBeforeDisplay: getComputedStyle(document.querySelector('.fate-ledger-header'), '::before').display,
-            ledgerHeaderAfterDisplay: getComputedStyle(document.querySelector('.fate-ledger-header'), '::after').display,
             headerDisplay: getComputedStyle(document.querySelector('.site-header')).display,
             footerDisplay: getComputedStyle(document.querySelector('.site-footer')).display,
             topExitText: topExit.textContent.trim(),
@@ -1091,18 +1066,14 @@ async function main() {
         assert(visualMetrics.hasFatePage, `Fate ${viewport.label} render should include the page shell`, errors);
         assert(visualMetrics.headerDisplay === 'none', `Fate ${viewport.label} render should hide the shared site header like Nemesis`, errors);
         assert(visualMetrics.footerDisplay === 'none', `Fate ${viewport.label} render should hide the shared site footer like Nemesis`, errors);
-        assert(!visualMetrics.headerBackgroundImage.includes('url('), `Fate ${viewport.label} header should not use decorative background images`, errors);
-        assert(visualMetrics.kenneyHeroCount === 1, `Fate ${viewport.label} hero should use the Kenney fantasy UI hero wrapper`, errors);
+        assert(visualMetrics.headerBackgroundImage.includes('linear-gradient'), `Fate ${viewport.label} header should render parchment texture`, errors);
+        assert(visualMetrics.rulebookHeroCount === 1, `Fate ${viewport.label} hero should use the rulebook hero wrapper`, errors);
+        assert(visualMetrics.heroPlateCount === 1, `Fate ${viewport.label} hero should render the title plate`, errors);
+        assert(visualMetrics.scriptBandCount === 1, `Fate ${viewport.label} hero should render decorative script marked aria-hidden`, errors);
+        assert(visualMetrics.calloutCount >= 2, `Fate ${viewport.label} render should include boxed rule callouts`, errors);
+        assert(visualMetrics.separatorCount >= 2, `Fate ${viewport.label} render should place runic separators between fixture sessions`, errors);
         assert(visualMetrics.posterArtCount === 0, `Fate ${viewport.label} hero should not render the rejected poster art image`, errors);
-        assert(visualMetrics.kenneyDividerCount >= 2, `Fate ${viewport.label} hero should render Kenney divider assets`, errors);
-        assert(visualMetrics.heroPanelBorderImageSource.includes('frame-hero-gold.png'), `Fate ${viewport.label} hero panel should use the Kenney hero frame`, errors);
-        assert(visualMetrics.heroPanelImageRendering === 'pixelated', `Fate ${viewport.label} hero panel should preserve the Kenney pixel-art border style`, errors);
-        assert(visualMetrics.sectionBorderImageSource.includes('frame-section-gold.png'), `Fate ${viewport.label} sections should use the Kenney section frame asset`, errors);
-        assert(visualMetrics.cardBorderImageSource.includes('frame-card-gold.png'), `Fate ${viewport.label} cards should use the Kenney card frame asset`, errors);
-        assert(visualMetrics.ledgerBeforeDisplay === 'none', `Fate ${viewport.label} should not render abstract ledger circle overlays`, errors);
-        assert(visualMetrics.sectionBeforeDisplay === 'none', `Fate ${viewport.label} should not fake scrollwork with section pseudo-corners`, errors);
-        assert(visualMetrics.ledgerHeaderBeforeDisplay === 'none', `Fate ${viewport.label} should not render abstract header ring overlays`, errors);
-        assert(visualMetrics.ledgerHeaderAfterDisplay === 'none', `Fate ${viewport.label} should not render abstract header line overlays`, errors);
+        assert(visualMetrics.ledgerBeforeDisplay === 'none', `Fate ${viewport.label} render should not show vertical ornamental side rails`, errors);
         assert(visualMetrics.topExitText === 'Exit to site', `Fate ${viewport.label} top exit should match the Nemesis exit label`, errors);
         assert(
           visualMetrics.topExitJustifySelf === 'end' || visualMetrics.topExitPosition === 'absolute',
@@ -1134,9 +1105,8 @@ async function main() {
         );
         assert(visualMetrics.h1Background === 'none', `Fate ${viewport.label} h1 should not inherit the site gradient`, errors);
         assert(
-          visualMetrics.h1FontFamily.includes('Uncial Antiqua') ||
-            visualMetrics.h1FontFamily.includes('Cinzel Decorative'),
-          `Fate ${viewport.label} h1 should use the Tolkien-inspired display font stack`,
+          visualMetrics.h1FontFamily.includes('Cinzel Decorative'),
+          `Fate ${viewport.label} h1 should use the rulebook display font stack`,
           errors
         );
         assert(


### PR DESCRIPTION
## Summary

- Replaces the Fate of the Fellowship tracker's pixel-art inn-ledger treatment with a simpler fantasy rulebook layout.
- Adds sparse runic decoration using `Noto Sans Runic`, removes overlapping SVG/map ornamentation, and keeps the page scoped away from the main site theme.
- Updates the Fate tracker tests to cover the new rulebook shell, runic separators, theme-safe buttons, hidden shared header/footer, readable parchment text, responsive behavior, and existing tracker/lightbox behavior.

## Validation

- `npm run test:fate`
- `npm run test:html`
- `npm run test:content`
- In-app browser desktop and mobile checks for title styling, no inherited gradient, and no horizontal overflow.